### PR TITLE
Add Optimizer to query ActiveRecord::Relation

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -43,8 +43,8 @@ module Blueprinter
       unless view_collection.has_view? view_name
         raise BlueprinterError, "View '#{view_name}' is not defined"
       end
-      prepared_object = Optimizer.new(object)
-                          .optimize!(view_collection.fields_for(view))
+      fields = view_collection.fields_for(view)
+      prepared_object = Optimizer.optimize!(object, fields: fields)
       prepared_object = include_associations(prepared_object, view_name: view_name)
       if prepared_object.respond_to? :map
         prepared_object.map do |obj|

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -44,7 +44,7 @@ module Blueprinter
         raise BlueprinterError, "View '#{view_name}' is not defined"
       end
       fields = view_collection.fields_for(view)
-      prepared_object = Optimizer.optimize!(object, fields: fields)
+      prepared_object = Optimizer.optimize(object, fields: fields)
       prepared_object = include_associations(prepared_object, view_name: view_name)
       if prepared_object.respond_to? :map
         prepared_object.map do |obj|

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -44,7 +44,7 @@ module Blueprinter
         raise BlueprinterError, "View '#{view_name}' is not defined"
       end
       prepared_object = Optimizer.new(object)
-                          .select(view_collection.fields_for(view))
+                          .optimize!(view_collection.fields_for(view))
       prepared_object = include_associations(prepared_object, view_name: view_name)
       if prepared_object.respond_to? :map
         prepared_object.map do |obj|

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -12,8 +12,8 @@ module Blueprinter
       private
 
       def active_record_relation?(object)
-        !!defined?(ActiveRecord::Relation) &&
-          object.is_a?(ActiveRecord::Relation)
+        !!(defined?(ActiveRecord::Relation) &&
+          object.is_a?(ActiveRecord::Relation))
       end
 
       def active_record_attributes_for(object)

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -1,36 +1,33 @@
 module Blueprinter
   class Optimizer
-    def initialize(object)
-      @object = object
-    end
+    class << self
+      def optimize!(object, fields:)
+        return object unless active_record_relation?(object)
+        select_columns = (active_record_attributes_for(object) &
+                         fields.map(&:method)) +
+                         required_lookup_attributes_for(object)
+        object.select(*select_columns)
+      end
 
-    def optimize!(fields)
-      return object unless active_record_relation?
-      select_columns = (active_record_attributes & fields.map(&:method)) +
-                       required_lookup_attributes
-      object.select(*select_columns)
-    end
+      private
 
-    private
+      def active_record_relation?(object)
+        !!defined?(ActiveRecord::Relation) &&
+          object.is_a?(ActiveRecord::Relation)
+      end
 
-    attr_reader :object
+      def active_record_attributes_for(object)
+        object.klass.column_names.map(&:to_sym)
+      end
 
-    def active_record_relation?
-      !!defined?(ActiveRecord::Relation) &&
-        object.is_a?(ActiveRecord::Relation)
-    end
-
-    def active_record_attributes
-      object.klass.column_names.map(&:to_sym)
-    end
-
-    def required_lookup_attributes
-      # TODO: We may not need all four of these
-      lookup_values = (object.includes_values +
-                       object.preload_values +
-                       object.joins_values +
-                       object.eager_load_values).uniq
-      lookup_values.map {|value| object.reflections[value.to_s].foreign_key}
+      def required_lookup_attributes_for(object)
+        # TODO: We may not need all four of these
+        lookup_values = (object.includes_values +
+                         object.preload_values +
+                         object.joins_values +
+                         object.eager_load_values).uniq
+        lookup_values.map {|value| object.reflections[value.to_s].foreign_key}
+      end
     end
   end
 end

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -4,7 +4,7 @@ module Blueprinter
       @object = object
     end
 
-    def select(fields)
+    def optimize!(fields)
       return object unless active_record_relation?
       select_columns = (active_record_attributes & fields.map(&:method)) +
                        required_lookup_attributes

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -1,0 +1,36 @@
+module Blueprinter
+  class Optimizer
+    def initialize(object)
+      @object = object
+    end
+
+    def select(fields)
+      return object unless active_record_relation?
+      select_columns = (active_record_attributes & fields.map(&:method)) +
+                       required_lookup_attributes
+      object.select(*select_columns)
+    end
+
+    private
+
+    attr_reader :object
+
+    def active_record_relation?
+      !!defined?(ActiveRecord::Relation) &&
+        object.is_a?(ActiveRecord::Relation)
+    end
+
+    def active_record_attributes
+      object.klass.column_names.map(&:to_sym)
+    end
+
+    def required_lookup_attributes
+      # TODO: We may not need all four of these
+      lookup_values = (object.includes_values +
+                       object.preload_values +
+                       object.joins_values +
+                       object.eager_load_values).uniq
+      lookup_values.map {|value| object.reflections[value.to_s].foreign_key}
+    end
+  end
+end

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -1,7 +1,7 @@
 module Blueprinter
   class Optimizer
     class << self
-      def optimize!(object, fields:)
+      def optimize(object, fields:)
         return object unless active_record_relation?(object)
         select_columns = (active_record_attributes_for(object) &
                          fields.map(&:method)) +


### PR DESCRIPTION
Add `Optimizer` to query `ActiveRecord::Relation`

1. detect for `ActiveRecord::Relation` instead of `ActiveRecord::Base`
objects for the time being since all the optimization methods we are
doing are actually `ActiveRecord::Relation` methods and not
`ActiveRecord::Base` methods.

2. Move all optimization related methods to it's own class, `Optimizer`

Resolves #8