### PR TITLE
Update circleci badge to use new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/procore/painted-rabbit.svg?style=svg)](https://circleci.com/gh/procore/painted-rabbit)
+[![CircleCI](https://circleci.com/gh/procore/blueprinter.svg?style=svg)](https://circleci.com/gh/procore/blueprinter)
 
 # Blueprinter
 Short description and motivation.


### PR DESCRIPTION
Due to #23, we now need to use new circleci badge that points to the new repo name.