### PR TITLE
Setup Yard - Rubydoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
+doc/
+.yardoc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    yard (0.9.9)
 
 PLATFORMS
   ruby
@@ -118,6 +119,7 @@ DEPENDENCIES
   factory_girl
   rails (~> 5.1.2)
   sqlite3
+  yard (~> 0.9.9)
 
 BUNDLED WITH
    1.15.4

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "yard", "~> 0.9.9"
 
   s.add_runtime_dependency "json"
 end

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -29,6 +29,19 @@ module Blueprinter
                                        options.merge(association: true))
     end
 
+    # Generates a JSON formatted String.
+    # Takes a required object and an optional view.
+    #
+    # @param object [Object] the Object to serialize upon.
+    # @param view [Symbol] the view name that corresponds to the group of
+    #   fields to be serialized.
+    #
+    # @example Generating JSON with an extended view
+    #   post = Post.all
+    #   Blueprinter::Base.render post, view: :extended
+    #   # => "[{\"id\":1,\"title\":\"Hello\"},{\"id\":2,\"title\":\"My Day\"}]"
+    #
+    # @return [String] JSON formatted String
     def self.render(object, view: :default)
       jsonify(prepare(object, view: view))
     end


### PR DESCRIPTION
Resoves #14 

Add Yard gem for documentation. Yard is what parses the yard tags and serves the
documentation. Yard is what powers rubydoc.info. 

Also documented the `Base.render` method as the first documented method using yard.

Yard is added in development runtime as it is only to be used in
development.

Official website of yard: https://yardoc.org/

yard github: https://github.com/lsegal/yard

We will eventually use http://rubydoc.info to make the docs available online.

In order to view docs in development: 
1. execute `yardoc` to generate docs
2. execute `yard server -r` to serve the docs from localhost:8808
3. navigate your browser to localhost:8808