### PR TITLE
Add pry for debugging in development

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       tzinfo (~> 1.1)
     arel (8.0.0)
     builder (3.2.3)
+    coderay (1.1.1)
     concurrent-ruby (1.0.5)
     erubi (1.6.1)
     factory_girl (4.8.0)
@@ -67,6 +68,10 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (2.0.3)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -94,6 +99,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
+    slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -116,6 +122,7 @@ PLATFORMS
 DEPENDENCIES
   blueprinter!
   factory_girl
+  pry
   rails (~> 5.1.2)
   sqlite3
 

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
+  s.add_development_dependency "pry"
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
 


### PR DESCRIPTION
Allow us to use `binding.pry` while in development to help us debug.