### PR TITLE
Document methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ gem install blueprinter
 We use [Yard](https://yardoc.org/) for documentation. Here are the following
 documentation rules:
 
-- Document public all methods we expect to be utilized by the end developers.
+- Document all public methods we expect to be utilized by the end developers.
 - Methods that are not set to private due to ruby visibility rule limitations should be marked with `@api private`.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Or install it yourself as:
 $ gem install blueprinter
 ```
 
+## Documentation
+
+We use [Yard](https://yardoc.org/) for documentation. Here are the following
+documentation rules:
+
+- Document public all methods we expect to be utilized by the end developers.
+- Methods that are not set to private due to ruby visibility rule limitations should be marked with `@api private`.
+
 ## Contributing
 Contribution directions go here.
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -13,10 +13,13 @@ module Blueprinter
     # Specify a field or method name used as an identifier. Usually, this is
     # something like :id
     #
+    # Note: identifiers are always rendered and considerered their own view,
+    # similar to the :default view.
+    #
     # @param method [Symbol] the method or field used as an identifier that you
     #   want to set for serialization.
     # @param name [Symbol] to rename the identifier key in the JSON
-    #   object. Defaults to method given.
+    #   output. Defaults to method given.
     # @param serializer [AssociationSerializer,PublicSendSerializer]
     #   Kind of serializer to use.
     #   Either define your own or use Blueprinter's premade serializers.
@@ -44,8 +47,8 @@ module Blueprinter
     #   Either define your own or use Blueprinter's premade serializers. The
     #   Default serializer is AssociationSerializer
     # @option options [Symbol] :name Use this to rename the method. Useful if
-    #   if you want your JSON key named differently than your object's field
-    #   or method name.
+    #   if you want your JSON key named differently in the output than your
+    #   object's field or method name.
     #
     # @example Specifying a user's first_name to be serialized.
     #   class UserBlueprint < Blueprinter::Base
@@ -66,7 +69,7 @@ module Blueprinter
     # @param method [Symbol] the association name
     # @param options [Hash] options to overide defaults.
     # @option options [Symbol] :name Use this to rename the association in the
-    #   JSON object.
+    #   JSON output.
     # @option options [Symbol] :view Specify the view to use or fall back to
     #   to the :default view.
     #
@@ -160,12 +163,13 @@ module Blueprinter
     #   class UserBlueprint < Blueprinter::Base
     #     # other code...
     #     view :normal do
-    #       # some fields set here
+    #       fields :first_name, :last_name
     #     end
     #     view :extended do
     #       include_view :normal # include fields specified from above.
     #       field :description
     #     end
+    #     #=> [:first_name, :last_name, :description]
     #   end
     #
     # @return [Array<Symbol>] an array of view names.
@@ -180,13 +184,14 @@ module Blueprinter
     #
     # @example Excluding a field from being included into the current view.
     #   view :normal do
-    #     fields :position, company
+    #     fields :position, :company
     #   end
     #   view :special do
-    #     include_view :extended
+    #     include_view :normal
     #     field :birthday
     #     exclude :position
     #   end
+    #   #=> [:company, :birthday]
     #
     # @return [Array<Symbol>] an array of field names
     def self.exclude(field_name)
@@ -203,7 +208,7 @@ module Blueprinter
     # @example Using views
     #   view :extended do
     #     fields :position, :company
-    #     include_view :extended
+    #     include_view :normal
     #     exclude :first_name
     #   end
     #

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -10,18 +10,74 @@ require_relative 'serializers/public_send_serializer'
 
 module Blueprinter
   class Base
+    # Specify a field or method name used as an identifier. Usually, this is
+    # something like :id
+    #
+    # @param method [Symbol] the method or field used as an identifier that you
+    #   want to set for serialization.
+    # @param name [Symbol] to rename the identifier key in the JSON
+    #   object. Defaults to method given.
+    # @param serializer [AssociationSerializer,PublicSendSerializer]
+    #   Kind of serializer to use.
+    #   Either define your own or use Blueprinter's premade serializers.
+    #   Defaults to PublicSendSerializer
+    #
+    # @example Specifying a uuid as an identifier.
+    #   class UserBlueprint < Blueprinter::Base
+    #     identifier :uuid
+    #     # other code
+    #   end
+    #
+    # @return [Field] A Field object
     def self.identifier(method, name: method, serializer: PublicSendSerializer)
       view_collection[:identifier] << Field.new(method, name, serializer)
     end
 
+    # Specify a field or method name to be included for serialization.
+    # Takes a required method and an option.
+    #
+    # @param method [Symbol] the field or method name you want to include for
+    #   serialization.
+    # @param options [Hash] options to overide defaults.
+    # @option options [AssociationSerializer,PublicSendSerializer] :serializer
+    #   Kind of serializer to use.
+    #   Either define your own or use Blueprinter's premade serializers. The
+    #   Default serializer is AssociationSerializer
+    # @option options [Symbol] :name Use this to rename the method. Useful if
+    #   if you want your JSON key named differently than your object's field
+    #   or method name.
+    #
+    # @example Specifying a user's first_name to be serialized.
+    #   class UserBlueprint < Blueprinter::Base
+    #     field :first_name
+    #     # other code
+    #   end
+    #
+    # @return [Field] A Field object
     def self.field(method, options = {})
       name = options.delete(:name) || method
       serializer = options.delete(:serializer) || AssociationSerializer
       current_view << Field.new(method, name, serializer, options)
     end
 
-    # Options:
-    #   preload: Set to false to stop trying to eagerly load associations
+    # Specify an associated object to be included for serialization.
+    # Takes a required method and an option.
+    #
+    # @param method [Symbol] the association name
+    # @param options [Hash] options to overide defaults.
+    # @option options [Symbol] :name Use this to rename the association in the
+    #   JSON object.
+    # @option options [Symbol] :view Specify the view to use or fall back to
+    #   to the :default view.
+    #
+    # @example Specifying an association
+    #   class UserBlueprint < Blueprinter::Base
+    #     # code
+    #     association :vehicles, view: :extended
+    #     # code
+    #   end
+    #
+    # @return [Field] A Field object
     def self.association(method, options = {})
       name = options.delete(:name) || method
       current_view << Field.new(method,
@@ -34,7 +90,8 @@ module Blueprinter
     # Takes a required object and an optional view.
     #
     # @param object [Object] the Object to serialize upon.
-    # @param view [Symbol] the view name that corresponds to the group of
+    # @param view [Symbol] Defaults to :default.
+    #   The view name that corresponds to the group of
     #   fields to be serialized.
     #
     # @example Generating JSON with an extended view
@@ -48,9 +105,12 @@ module Blueprinter
     end
 
     # This is the magic method that converts complex objects into a simple hash
-    # ready for JSON conversion
+    # ready for JSON conversion.
+    #
     # Note: we accept view (public interface) that is in reality a view_name,
-    #   so we rename it for clarity
+    # so we rename it for clarity
+    #
+    # @api private
     def self.prepare(object, view:)
       view_name = view
       unless view_collection.has_view? view_name
@@ -68,24 +128,86 @@ module Blueprinter
       end
     end
 
+    # Specify one or more field/method names to be included for serialization.
+    # Takes at least one field or method names.
+    #
+    # @param method [Symbol] the field or method name you want to include for
+    #   serialization.
+    #
+    # @example Specifying a user's first_name and last_name to be serialized.
+    #   class UserBlueprint < Blueprinter::Base
+    #     fields :first_name, :last_name
+    #     # other code
+    #   end
+    #
+    # @return [Array<Symbol>] an array of field names
     def self.fields(*field_names)
       field_names.each do |field_name|
         current_view << Field.new(field_name, field_name, PublicSendSerializer)
       end
     end
 
+    # @api private
     def self.associations(view_name = :default)
       view_collection.fields_for(view_name).select { |f| f.options[:association] }
     end
 
+    # Specify another view that should be mixed into the current view.
+    #
+    # @param view_name [Symbol] the view to mix into the current view.
+    #
+    # @example Including a normal view into an extended view.
+    #   class UserBlueprint < Blueprinter::Base
+    #     # other code...
+    #     view :normal do
+    #       # some fields set here
+    #     end
+    #     view :extended do
+    #       include_view :normal # include fields specified from above.
+    #       field :description
+    #     end
+    #   end
+    #
+    # @return [Array<Symbol>] an array of view names.
     def self.include_view(view_name)
       current_view.include_view(view_name)
     end
 
+
+    # Exclude a field that was mixed into the current view.
+    #
+    # @param field_name [Symbol] the field to exclude from the current view.
+    #
+    # @example Excluding a field from being included into the current view.
+    #   view :normal do
+    #     fields :position, company
+    #   end
+    #   view :special do
+    #     include_view :extended
+    #     field :birthday
+    #     exclude :position
+    #   end
+    #
+    # @return [Array<Symbol>] an array of field names
     def self.exclude(field_name)
       current_view.exclude_field(field_name)
     end
 
+    # Specify a view and the fields it should have.
+    # It accepts a view name and a block. The block should specify the fields.
+    #
+    # @param view_name [Symbol] the view name
+    # @yieldreturn [#fields,#field,#include_view,#exclude] Use this block to
+    #   specify fields, include fields from other views, or exclude fields.
+    #
+    # @example Using views
+    #   view :extended do
+    #     fields :position, :company
+    #     include_view :extended
+    #     exclude :first_name
+    #   end
+    #
+    # @return [View] a Blueprinter::View object
     def self.view(view_name)
       @current_view = view_collection[view_name]
       yield

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -1,3 +1,4 @@
+# @api private
 class Blueprinter::Field
   attr_reader :method, :name, :serializer, :options
   def initialize(method, name, serializer, options = {})

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class Optimizer
     class << self
       def optimize(object, fields:)

--- a/lib/blueprinter/serializer.rb
+++ b/lib/blueprinter/serializer.rb
@@ -1,3 +1,4 @@
+# @api private
 class Blueprinter::Serializer
   def initialize
   end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class View
     attr_reader :fields, :included_view_names, :excluded_field_names
 

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class ViewCollection
     attr_reader :views
     def initialize


### PR DESCRIPTION
- Adds yard inline docs to the public methods
- Mark private methods that are visible private. Marking them private warns devs not to use it as those methods could change any time and without warning.

The best way to see the docs is to:
1. bring the branch down locally.
2. `yard server -r`
3. Navigate to localhost:8808

#26 