### PR TITLE
Rename serializer option to blueprint

### DIFF
--- a/lib/blueprinter/serializers/association_serializer.rb
+++ b/lib/blueprinter/serializers/association_serializer.rb
@@ -1,8 +1,8 @@
 class Blueprinter::AssociationSerializer < Blueprinter::Serializer
   def serialize(association_name, object, options={})
-    if options[:serializer]
+    if options[:blueprint]
       view = options[:view] || :default
-      options[:serializer].prepare(object.public_send(association_name), view: view)
+      options[:blueprint].prepare(object.public_send(association_name), view: view)
     else
       object.public_send(association_name)
     end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -5,7 +5,7 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 
   test 'simple model serializer' do
-    simple_user_serializer_class = Class.new(Blueprinter::Base) do
+    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
       identifier :id
       field :email
       fields :last_name, :first_name
@@ -20,7 +20,7 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
       last_name: user.last_name
     })
 
-    assert_equal(expected_result, simple_user_serializer_class.render(user))
+    assert_equal(expected_result, simple_user_blueprint_class.render(user))
   end
 
   test 'model serializer with views' do

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -52,7 +52,7 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
   end
 
   test 'model serializer with associations' do
-    simple_vehicle_serializer_class = Class.new(Blueprinter::Base) do
+    simple_vehicle_blueprint_class = Class.new(Blueprinter::Base) do
       identifier :id
       fields :make, :model
 
@@ -67,7 +67,7 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
       fields :last_name, :first_name
 
       view :normal do
-        association :vehicles, serializer: simple_vehicle_serializer_class
+        association :vehicles, blueprint: simple_vehicle_blueprint_class
       end
     end
 
@@ -89,7 +89,7 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
   end
 
   test 'model serializer with associations with views' do
-    vehicle_view_serializer_class = Class.new(Blueprinter::Base) do
+    vehicle_view_blueprint_class = Class.new(Blueprinter::Base) do
       identifier :id
       fields :make, :model
 
@@ -104,7 +104,7 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
       fields :last_name, :first_name
 
       view :normal do
-        association :vehicles, serializer: vehicle_view_serializer_class, view: :extended
+        association :vehicles, blueprint: vehicle_view_blueprint_class, view: :extended
       end
     end
 


### PR DESCRIPTION
options[:serializer] should be options[:blueprint]

When working with an association, we expect end developers to create
their own blueprint and pass it as an option like so:
`association :vehicles, blueprint: VehicleBlueprint `.

Previously calling the option `:serializer` was incorrect.

resolves #34