### PR TITLE
Add local methods

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -71,9 +71,11 @@ module Blueprinter
         {name: method, serializer: BlockSerializer, block: {method => block}}
       else
         {name: method, serializer: AssociationSerializer}
-      end.merge options
-      current_view << Field.new(method, options[:name], options[:serializer],
-        options)
+      end.merge(options)
+      current_view << Field.new(method,
+                                options[:name],
+                                options[:serializer],
+                                options)
     end
 
     # Specify an associated object to be included for serialization.

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -7,6 +7,7 @@ require_relative 'view_collection'
 require_relative 'optimizer'
 require_relative 'serializers/association_serializer'
 require_relative 'serializers/public_send_serializer'
+require_relative 'serializers/local_method_serializer'
 
 module Blueprinter
   class Base
@@ -217,6 +218,11 @@ module Blueprinter
       @current_view = view_collection[view_name]
       yield
       @current_view = view_collection[:default]
+    end
+
+    def self.local_method(method)
+      options = {local_methods: {method => yield}}
+      current_view << Field.new(method, method, LocalMethodSerializer, options)
     end
 
     private

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -231,8 +231,8 @@ module Blueprinter
     #   local_method(:age) { 31 }
     #
     # @return [Field] A Field object
-    def self.local_method(method)
-      options = {local_methods: {method => yield}}
+    def self.local_method(method, &block)
+      options = {local_methods: {method => block}}
       current_view << Field.new(method, method, LocalMethodSerializer, options)
     end
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -220,6 +220,17 @@ module Blueprinter
       @current_view = view_collection[:default]
     end
 
+    # Specify a custom local method which executes the code in the block.
+    # It accepts the name of the method as a symbol and a block.
+    #
+    # @param view_name [Symbol] the method name.
+    # @yield Use this block to define your method body.
+    #
+    # @example Using views
+    #   fields :position, :company
+    #   local_method(:age) { 31 }
+    #
+    # @return [Field] A Field object
     def self.local_method(method)
       options = {local_methods: {method => yield}}
       current_view << Field.new(method, method, LocalMethodSerializer, options)

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -7,7 +7,6 @@ require_relative 'view_collection'
 require_relative 'optimizer'
 require_relative 'serializers/association_serializer'
 require_relative 'serializers/public_send_serializer'
-require_relative 'serializers/local_method_serializer'
 require_relative 'serializers/block_serializer'
 
 module Blueprinter
@@ -231,22 +230,6 @@ module Blueprinter
       @current_view = view_collection[view_name]
       yield
       @current_view = view_collection[:default]
-    end
-
-    # Specify a custom local method which executes the code in the block.
-    # It accepts the name of the method as a symbol and a block.
-    #
-    # @param view_name [Symbol] the method name.
-    # @yield Use this block to define your method body.
-    #
-    # @example Using views
-    #   fields :position, :company
-    #   local_method(:age) { 31 }
-    #
-    # @return [Field] A Field object
-    def self.local_method(method, &block)
-      options = {local_methods: {method => block}}
-      current_view << Field.new(method, method, LocalMethodSerializer, options)
     end
 
     private

--- a/lib/blueprinter/serializers/block_serializer.rb
+++ b/lib/blueprinter/serializers/block_serializer.rb
@@ -1,0 +1,5 @@
+class Blueprinter::BlockSerializer < Blueprinter::Serializer
+  def serialize(field_name, object, options = {})
+    options[:block][field_name].call(object)
+  end
+end

--- a/lib/blueprinter/serializers/local_method_serializer.rb
+++ b/lib/blueprinter/serializers/local_method_serializer.rb
@@ -1,5 +1,5 @@
 class Blueprinter::LocalMethodSerializer < Blueprinter::Serializer
-  def serialize(field_name, _object, options = {})
-    options[:local_methods][field_name]
+  def serialize(field_name, object, options = {})
+    options[:local_methods][field_name].call(object)
   end
 end

--- a/lib/blueprinter/serializers/local_method_serializer.rb
+++ b/lib/blueprinter/serializers/local_method_serializer.rb
@@ -1,5 +1,0 @@
-class Blueprinter::LocalMethodSerializer < Blueprinter::Serializer
-  def serialize(field_name, object, options = {})
-    options[:local_methods][field_name].call(object)
-  end
-end

--- a/lib/blueprinter/serializers/local_method_serializer.rb
+++ b/lib/blueprinter/serializers/local_method_serializer.rb
@@ -1,0 +1,5 @@
+class Blueprinter::LocalMethodSerializer < Blueprinter::Serializer
+  def serialize(field_name, _object, options = {})
+    options[:local_methods][field_name]
+  end
+end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -125,4 +125,25 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
     })
     assert_equal(expected_result, user_association_serializer_class.render(user, view: :normal))
   end
+
+  test 'model serializer with local methods' do
+    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      field :email
+      fields :last_name, :first_name
+      local_method(:age) { 30 + 1 }
+    end
+
+    user = create(:user)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      age: 31,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name
+    })
+
+    assert_equal(expected_result, simple_user_blueprint_class.render(user))
+  end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -167,4 +167,20 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
 
     assert_equal(expected_result, simple_user_blueprint_class.render(user))
   end
+
+  test 'model serializer with a field and block' do
+    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      field :full_name {|obj| "#{obj.first_name} #{obj.last_name}"}
+    end
+
+    user = create(:user)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      full_name: "#{user.first_name} #{user.last_name}",
+    })
+
+    assert_equal(expected_result, simple_user_blueprint_class.render(user))
+  end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -126,48 +126,6 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal(expected_result, user_association_serializer_class.render(user, view: :normal))
   end
 
-  test 'model serializer with local methods' do
-    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
-      identifier :id
-      field :email
-      fields :last_name, :first_name
-      local_method(:age) { 30 + 1 }
-    end
-
-    user = create(:user)
-
-    expected_result = JSON.generate({
-      id: user.id,
-      age: 31,
-      email: user.email,
-      first_name: user.first_name,
-      last_name: user.last_name
-    })
-
-    assert_equal(expected_result, simple_user_blueprint_class.render(user))
-  end
-
-  test 'model serializer with local method and object' do
-    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
-      identifier :id
-      field :email
-      fields :last_name, :first_name
-      local_method :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
-    end
-
-    user = create(:user)
-
-    expected_result = JSON.generate({
-      id: user.id,
-      email: user.email,
-      first_name: user.first_name,
-      full_name: "#{user.first_name} #{user.last_name}",
-      last_name: user.last_name
-    })
-
-    assert_equal(expected_result, simple_user_blueprint_class.render(user))
-  end
-
   test 'model serializer with a field and block' do
     simple_user_blueprint_class = Class.new(Blueprinter::Base) do
       identifier :id

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -146,4 +146,25 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
 
     assert_equal(expected_result, simple_user_blueprint_class.render(user))
   end
+
+  test 'model serializer with local method and object' do
+    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      field :email
+      fields :last_name, :first_name
+      local_method :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
+    end
+
+    user = create(:user)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      full_name: "#{user.first_name} #{user.last_name}",
+      last_name: user.last_name
+    })
+
+    assert_equal(expected_result, simple_user_blueprint_class.render(user))
+  end
 end

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -102,4 +102,14 @@ class Blueprinter::Test < Minitest::Test
     assert_equal('{"id":1,"address":"777 Test Dr","age":31,"name":"Meg"}',
                  simple_blueprinter_class.render(my_obj))
   end
+
+  def test_local_method_and_object
+    my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
+    simple_blueprinter_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      local_method :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
+    end
+    assert_equal('{"id":1,"full_name":"Meg Ryan"}',
+                 simple_blueprinter_class.render(my_obj))
+  end
 end

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -112,4 +112,14 @@ class Blueprinter::Test < Minitest::Test
     assert_equal('{"id":1,"full_name":"Meg Ryan"}',
                  simple_blueprinter_class.render(my_obj))
   end
+
+  def test_field_with_block
+    my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
+    simple_blueprinter_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      field :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
+    end
+    assert_equal('{"id":1,"full_name":"Meg Ryan"}',
+                 simple_blueprinter_class.render(my_obj))
+  end
 end

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -90,4 +90,16 @@ class Blueprinter::Test < Minitest::Test
       'The special view should render the right fields'
     )
   end
+
+  def test_local_methods
+    my_obj = OpenStruct.new(id: 1, name: 'Meg')
+    simple_blueprinter_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      fields :name
+      local_method :age { 30 + 1 }
+      local_method :address { '777 Test Dr' }
+    end
+    assert_equal('{"id":1,"address":"777 Test Dr","age":31,"name":"Meg"}',
+                 simple_blueprinter_class.render(my_obj))
+  end
 end

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -91,28 +91,6 @@ class Blueprinter::Test < Minitest::Test
     )
   end
 
-  def test_local_methods
-    my_obj = OpenStruct.new(id: 1, name: 'Meg')
-    simple_blueprinter_class = Class.new(Blueprinter::Base) do
-      identifier :id
-      fields :name
-      local_method :age { 30 + 1 }
-      local_method :address { '777 Test Dr' }
-    end
-    assert_equal('{"id":1,"address":"777 Test Dr","age":31,"name":"Meg"}',
-                 simple_blueprinter_class.render(my_obj))
-  end
-
-  def test_local_method_and_object
-    my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
-    simple_blueprinter_class = Class.new(Blueprinter::Base) do
-      identifier :id
-      local_method :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
-    end
-    assert_equal('{"id":1,"full_name":"Meg Ryan"}',
-                 simple_blueprinter_class.render(my_obj))
-  end
-
   def test_field_with_block
     my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
     simple_blueprinter_class = Class.new(Blueprinter::Base) do


### PR DESCRIPTION
Resolves #32

~Add a method call `local_method`.  `local_method` accepts a method name and a method body. The method name is passed as an argument, and the method body is passed into a block.~

~Why we need something like this? There are situations where end devs want to define a method that are not used anywhere else except to have it serialized into JSON.~

Usage:
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :id
  fields :name
  local_method :age { 30 + 1 }
end
```

~So currently this works. But I also just now realized that it's use cases are currently narrow without first tackling #33. #33 would allow end developers to pass in custom options from `render` and utilize that in their blueprint class.~

Update: 10/20
~Now object is passed into the block so you can use it like so:~
``` ruby
class UserBlueprint < Blueprinter::Base
  identifier :id
  fields :first_name
  local_method(:full_name) do |obj|
    "#{obj.first_name} #{obj.last_name}"
  end
end
```

Update 10/23
We allow the passing of a block to `field` like so:
```ruby
class UserBlueprint < Blueprinter::Base
  # This would create a key value pair in the json output that looks like this:
  # {"full_name": "Jon Doe"}
  field(:full_name) do |obj|
    "#{obj.first_name} #{obj.last_name}"
  end
end
```