### PR TITLE
Render with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Blueprinter
 Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant.
 
-It heavily relies on the idea of `views` which, similar to Rails views, are ways of predefining output for data in different contexts. 
+It heavily relies on the idea of `views` which, similar to Rails views, are ways of predefining output for data in different contexts.
 
 ## Documentation
 !TODO Link to the docs
@@ -17,7 +17,7 @@ You may define a simple blueprint like so:
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  
+
   fields :first_name, :last_name, :email
 end
 ```
@@ -44,7 +44,7 @@ You may define different ouputs by utilizing views:
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
   field :email, name: :login
-  
+
   view :normal do
     fields :first_name, :last_name
   end
@@ -79,7 +79,7 @@ You may include associated objects. Say for example, a user has projects:
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
   field :email, name: :login
-  
+
   view :normal do
     fields :first_name, :last_name
     association :projects
@@ -137,6 +137,34 @@ Output:
 {
   "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
   "full_name": "John Doe"
+}
+```
+
+### Passing additional properties to `render`
+
+`render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+  field(:company_name) do |_user, options|
+    options[:company].name
+  end
+end
+```
+
+Usage:
+
+```ruby
+puts UserBlueprint.render(user, company: company)
+```
+
+Output:
+
+```json
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+  "company_name": "My Company LLC"
 }
 ```
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -108,7 +108,9 @@ module Blueprinter
     # Takes a required object and an optional view.
     #
     # @param object [Object] the Object to serialize upon.
-    # @param view [Symbol] Defaults to :default.
+    # @param options [Hash] the options hash which requires a :view. Any
+    #   additional key value pairs will be exposed during serialization.
+    # @option options [Symbol] :view Defaults to :default.
     #   The view name that corresponds to the group of
     #   fields to be serialized.
     #

--- a/lib/blueprinter/serializer.rb
+++ b/lib/blueprinter/serializer.rb
@@ -3,11 +3,11 @@ class Blueprinter::Serializer
   def initialize
   end
 
-  def serialize(field_name, object, options={})
+  def serialize(field_name, object, local_options, options={})
     fail NotImplementedError, "A serializer must implement #serialize"
   end
 
-  def self.serialize(field_name, object, options={})
-    self.new.serialize(field_name, object, options)
+  def self.serialize(field_name, object, local_options, options={})
+    self.new.serialize(field_name, object, local_options, options)
   end
 end

--- a/lib/blueprinter/serializers/association_serializer.rb
+++ b/lib/blueprinter/serializers/association_serializer.rb
@@ -1,8 +1,8 @@
 class Blueprinter::AssociationSerializer < Blueprinter::Serializer
-  def serialize(association_name, object, options={})
+  def serialize(association_name, object, local_options, options={})
     if options[:blueprint]
       view = options[:view] || :default
-      options[:blueprint].prepare(object.public_send(association_name), view: view)
+      options[:blueprint].prepare(object.public_send(association_name), view_name: view, local_options: local_options)
     else
       object.public_send(association_name)
     end

--- a/lib/blueprinter/serializers/block_serializer.rb
+++ b/lib/blueprinter/serializers/block_serializer.rb
@@ -1,5 +1,5 @@
 class Blueprinter::BlockSerializer < Blueprinter::Serializer
-  def serialize(field_name, object, options = {})
-    options[:block][field_name].call(object)
+  def serialize(field_name, object, local_options, options = {})
+    options[:block][field_name].call(object, local_options)
   end
 end

--- a/lib/blueprinter/serializers/public_send_serializer.rb
+++ b/lib/blueprinter/serializers/public_send_serializer.rb
@@ -1,5 +1,5 @@
 class Blueprinter::PublicSendSerializer < Blueprinter::Serializer
-  def serialize(field_name, object, options = {})
+  def serialize(field_name, object, local_options, options = {})
     object.public_send(field_name)
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -141,4 +141,22 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
 
     assert_equal(expected_result, simple_user_blueprint_class.render(user))
   end
+
+  test 'render with options' do
+    simple_user_blueprint_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      field :vehicle_name {|_obj, options| options[:vehicle].make}
+    end
+
+    user = create(:user)
+    vehicle = create(:vehicle)
+
+    expected_result = JSON.generate({
+      id: user.id,
+      vehicle_name: "#{vehicle.make}",
+    })
+
+    assert_equal(expected_result,
+                 simple_user_blueprint_class.render(user, vehicle: vehicle))
+  end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -145,7 +145,9 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
   test 'render with options' do
     simple_user_blueprint_class = Class.new(Blueprinter::Base) do
       identifier :id
-      field :vehicle_name {|_obj, options| options[:vehicle].make}
+      field :vehicle_name do |_obj, options|
+        options[:vehicle].make
+      end
     end
 
     user = create(:user)

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -29,7 +29,7 @@ class Blueprinter::Test < Minitest::Test
 
   def test_fields_using_custom_serializers
     upcase_serializer = Class.new(Blueprinter::Serializer) do
-      def serialize(field_name, object, options={})
+      def serialize(field_name, object, _local_options, _options={})
         object.public_send(field_name).upcase
       end
     end
@@ -91,13 +91,14 @@ class Blueprinter::Test < Minitest::Test
     )
   end
 
-  def test_field_with_block
-    my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
+  def test_render_with_options
+    user = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
+    vehicle = OpenStruct.new(id: 1, make: 'Super Car')
     simple_blueprinter_class = Class.new(Blueprinter::Base) do
       identifier :id
-      field :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
+      field :vehicle_make { |_obj, options| "#{options[:vehicle].make}" }
     end
-    assert_equal('{"id":1,"full_name":"Meg Ryan"}',
-                 simple_blueprinter_class.render(my_obj))
+    assert_equal('{"id":1,"vehicle_make":"Super Car"}',
+                 simple_blueprinter_class.render(user, vehicle: vehicle))
   end
 end

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -106,7 +106,9 @@ class Blueprinter::Test < Minitest::Test
     vehicle = OpenStruct.new(id: 1, make: 'Super Car')
     simple_blueprinter_class = Class.new(Blueprinter::Base) do
       identifier :id
-      field :vehicle_make { |_obj, options| "#{options[:vehicle].make}" }
+      field :vehicle_make do |_obj, options|
+        "#{options[:vehicle].make}"
+      end
     end
     assert_equal('{"id":1,"vehicle_make":"Super Car"}',
                  simple_blueprinter_class.render(user, vehicle: vehicle))

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -91,6 +91,16 @@ class Blueprinter::Test < Minitest::Test
     )
   end
 
+  def test_field_with_block
+    my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
+    simple_blueprinter_class = Class.new(Blueprinter::Base) do
+      identifier :id
+      field :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
+    end
+    assert_equal('{"id":1,"full_name":"Meg Ryan"}',
+                 simple_blueprinter_class.render(my_obj))
+  end
+
   def test_render_with_options
     user = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
     vehicle = OpenStruct.new(id: 1, make: 'Super Car')


### PR DESCRIPTION
Allow `render` to take an options hash.
    
This `options` hash is internally called `local_options`, and it is
passed through to the serializer. 

I wanted to clearly distinguish options passed in through render, and the previously used options that was stored in Field. So i named the options passed in by render as `local_options`.
    
End devs can now pass an options hash to `render` and use it in the `field` block like this:
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :company_id {|obj, options| options.company.id }
end

UserBlueprint.render(user, company: company)
#=> {"uuid": "x2334fw987a", "company_id": 2}
```