### PR TITLE
Conform tests to Ruby 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Blueprinter
 Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant.
 
-It heavily relies on the idea of `views` which, similar to Rails views, are ways of predefining output for data in different contexts. 
+It heavily relies on the idea of `views` which, similar to Rails views, are ways of predefining output for data in different contexts.
 
 ## Documentation
 !TODO Link to the docs
@@ -17,7 +17,7 @@ You may define a simple blueprint like so:
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  
+
   fields :first_name, :last_name, :email
 end
 ```
@@ -44,7 +44,7 @@ You may define different ouputs by utilizing views:
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
   field :email, name: :login
-  
+
   view :normal do
     fields :first_name, :last_name
   end
@@ -79,7 +79,7 @@ You may include associated objects. Say for example, a user has projects:
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
   field :email, name: :login
-  
+
   view :normal do
     fields :first_name, :last_name
     association :projects

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can define a field directly in the Blueprint by passing it a block. This is 
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
-  field(:full_name) do |user|
+  field :full_name do |user|
     "#{user.first_name} #{user.last_name}"
   end
 end

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.4.1
+    version: 2.2.2
 
 database:
   override:

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -129,7 +129,9 @@ class Blueprinter::ActiveRecordTest < ActiveSupport::TestCase
   test 'model serializer with a field and block' do
     simple_user_blueprint_class = Class.new(Blueprinter::Base) do
       identifier :id
-      field :full_name {|obj| "#{obj.first_name} #{obj.last_name}"}
+      field :full_name do |obj|
+        "#{obj.first_name} #{obj.last_name}"
+      end
     end
 
     user = create(:user)

--- a/test/blueprinter_test.rb
+++ b/test/blueprinter_test.rb
@@ -95,7 +95,9 @@ class Blueprinter::Test < Minitest::Test
     my_obj = OpenStruct.new(id: 1, first_name: 'Meg', last_name: 'Ryan')
     simple_blueprinter_class = Class.new(Blueprinter::Base) do
       identifier :id
-      field :full_name { |obj| "#{obj.first_name} #{obj.last_name}" }
+      field :full_name do |obj|
+        "#{obj.first_name} #{obj.last_name}"
+      end
     end
     assert_equal('{"id":1,"full_name":"Meg Ryan"}',
                  simple_blueprinter_class.render(my_obj))


### PR DESCRIPTION
Prior to 2.4, Ruby does not handle mixing block arguments with regular arguments
WITHOUT parens correctly. Ideally, our DSL would look like:
```ruby
field :name { |obj| ... }
```
but <2.4 reads this like
```ruby
field(:name); { |obj ... }
```
finishing the method call before the block is even considered.