### PR TITLE
IPS are slower due to ruby downgrade.

### DIFF
--- a/test/benchmarks/active_record_ips_test.rb
+++ b/test/benchmarks/active_record_ips_test.rb
@@ -16,6 +16,6 @@ class Blueprinter::ActiveRecordIPSTest < Minitest::Test
   def test_render
     result = iterate {@blueprinter.render(@prepared_objects)}
     puts "\nActiveRecord IPS: #{result}"
-    assert_operator(result, :>=, 2500)
+    assert_operator(result, :>=, 2000)
   end
 end

--- a/test/benchmarks/ips_test.rb
+++ b/test/benchmarks/ips_test.rb
@@ -16,6 +16,6 @@ class Blueprinter::IPSTest < Minitest::Test
   def test_render
     result = iterate {@blueprinter.render(@prepared_objects)}
     puts "\nBasic IPS: #{result}"
-    assert_operator(result, :>=, 3000)
+    assert_operator(result, :>=, 2500)
   end
 end


### PR DESCRIPTION
Previously, we were building and running benchmarks on circle ci using
ruby 2.4.1. We now build and run benchmarks on 2.2.2. Ruby 2.2.2 is
slower than 2.4.1, so we need to reduce the IPS benchmarks. Otherwise, we
would get benchmark failures too regularly.