### PR TITLE
Fix default serialzer for `Base.field`

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -46,7 +46,7 @@ module Blueprinter
     # @option options [AssociationSerializer,PublicSendSerializer] :serializer
     #   Kind of serializer to use.
     #   Either define your own or use Blueprinter's premade serializers. The
-    #   Default serializer is AssociationSerializer
+    #   Default serializer is PublicSendSerializer
     # @option options [Symbol] :name Use this to rename the method. Useful if
     #   if you want your JSON key named differently in the output than your
     #   object's field or method name.
@@ -70,7 +70,7 @@ module Blueprinter
       options = if block_given?
         {name: method, serializer: BlockSerializer, block: {method => block}}
       else
-        {name: method, serializer: AssociationSerializer}
+        {name: method, serializer: PublicSendSerializer}
       end.merge(options)
       current_view << Field.new(method,
                                 options[:name],


### PR DESCRIPTION
It should be `PublicSendSerializer` and not `AssociationSerializer`. While both works, `PublicSendSerializer` is more efficient and was made for this use case.

Resolves #30