### PR TITLE
Update yard version for security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    yard (0.9.9)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -126,7 +126,7 @@ DEPENDENCIES
   pry
   rails (~> 5.1.2)
   sqlite3
-  yard (~> 0.9.9)
+  yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "yard", "~> 0.9.9"
+  s.add_development_dependency "yard", "~> 0.9.11"
 
   s.add_runtime_dependency "json"
 end


### PR DESCRIPTION
Due to a security vulnerability in yard < 0.9.11, bumps the yard version to ~> 0.9.11