### PR TITLE
Configurable json generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    oj (3.3.10)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -135,6 +136,7 @@ PLATFORMS
 DEPENDENCIES
   blueprinter!
   factory_girl
+  oj (~> 3.0)
   pry
   rails (~> 5.1.2)
   rspec (~> 3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     blueprinter (0.1.0)
-      json
 
 GEM
   remote: https://rubygems.org/
@@ -55,7 +54,6 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
-    json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ Or install it yourself as:
 $ gem install blueprinter
 ```
 
+You should also have `require 'json'` already in your project if you are not using Rails or if you are not using Oj.
+
+## OJ
+
+By default, Blueprinter will be calling `JSON.generate(object)` internally and it expects that you have `require 'json'` already in your project's code. You may use `Oj` to generate in place of `JSON` like so:
+
+```ruby
+require 'oj' # you can skip this if OJ has already been required.
+
+Blueprinter.configure do |config|
+  config.generator = Oj # default is JSON
+end
+```
+
+Ensure that you have the `Oj` gem installed in your Gemfile if you haven't already:
+
+```ruby
+# Gemfile
+gem 'oj'
+```
+
 ## Documentation
 
 We use [Yard](https://yardoc.org/) for documentation. Here are the following

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
+  s.add_development_dependency "oj", "~> 3.0"
   s.add_development_dependency "pry"
   s.add_development_dependency "rails", "~> 5.1.2"
   s.add_development_dependency "rspec", "~> 3.7"

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -23,6 +23,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.7"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "yard", "~> 0.9.11"
-
-  s.add_runtime_dependency "json"
 end

--- a/lib/blueprinter.rb
+++ b/lib/blueprinter.rb
@@ -1,3 +1,4 @@
+require_relative 'blueprinter/configuration'
 require_relative 'blueprinter/base'
 
 module Blueprinter

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -271,11 +271,7 @@ module Blueprinter
     private_class_method :include_associations
 
     def self.jsonify(blob)
-      if blob.respond_to? :to_json
-        blob.to_json
-      else
-        JSON.generate(blob)
-      end
+      Blueprinter.configuration.generator.generate(blob)
     end
     private_class_method :jsonify
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -1,4 +1,3 @@
-require 'json'
 require_relative 'blueprinter_error'
 require_relative 'field'
 require_relative 'serializer'

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,0 +1,17 @@
+module Blueprinter
+  class Configuration
+    attr_accessor :generator
+
+    def initialize
+      @generator = JSON
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration if block_given?
+  end
+end

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -1,0 +1,13 @@
+require 'oj'
+
+describe '::Configuration' do
+  describe '#generator' do
+    before { Blueprinter.configure { |config| config.generator = JSON } }
+    after { Blueprinter.configure { |config| config.generator = JSON } }
+
+    it 'should set the generator' do
+      Blueprinter.configure { |config| config.generator = Oj }
+      expect(Blueprinter.configuration.generator).to be(Oj)
+    end
+  end
+end


### PR DESCRIPTION
The goal of this PR is to allow developers to utilize Oj to generate the JSON. This is to resolve issue #17. I would love some careful eyes on this, ideas, opinions.

You will notice that I removed the JSON gem dependency. That is done because the JSON gem and the subsequent `require 'json'` will override core ruby classes to add the `to_json` method. The override is global and it will affect everything in the developer's project. If the developer had already overridden classes with their own `to_json`, then we do not want to override that.

Instead, it is up to the developer to decide whether they want to use the JSON gem or Oj. Once they have installed and required the JSON gem or the Oj gem, they can configure Blueprinter to use whichever one of those:

```ruby
Blueprinter.configure do |config|
  config.generator = Oj # default is JSON
end
```