### PR TITLE
Support hash object passed to render

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -244,10 +244,7 @@ module Blueprinter
 
     def self.object_to_hash(object, view_name:, local_options:)
       view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
-        hash[field.name] = field.serializer.serialize(field.method,
-                                                      object,
-                                                      local_options,
-                                                      field.options)
+        hash[field.name] = field.serialize(object, local_options)
       end
     end
     private_class_method :object_to_hash

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -7,4 +7,8 @@ class Blueprinter::Field
     @serializer = serializer
     @options = options
   end
+
+  def serialize(object, local_options)
+    serializer.serialize(method, object, local_options, options)
+  end
 end

--- a/lib/blueprinter/helpers/active_record_helpers.rb
+++ b/lib/blueprinter/helpers/active_record_helpers.rb
@@ -1,0 +1,18 @@
+module Blueprinter
+  module ActiveRecordHelpers
+    def self.included(base)
+      base.extend(SingletonMethods)
+    end
+
+    def active_record_relation?(object)
+      self.class.active_record_relation?(object)
+    end
+
+    module SingletonMethods
+      def active_record_relation?(object)
+        !!(defined?(ActiveRecord::Relation) &&
+          object.is_a?(ActiveRecord::Relation))
+      end
+    end
+  end
+end

--- a/lib/blueprinter/optimizer.rb
+++ b/lib/blueprinter/optimizer.rb
@@ -1,6 +1,7 @@
 module Blueprinter
   # @api private
   class Optimizer
+    include ActiveRecordHelpers
     class << self
       def optimize(object, fields:)
         return object unless active_record_relation?(object)
@@ -11,11 +12,6 @@ module Blueprinter
       end
 
       private
-
-      def active_record_relation?(object)
-        !!(defined?(ActiveRecord::Relation) &&
-          object.is_a?(ActiveRecord::Relation))
-      end
 
       def active_record_attributes_for(object)
         object.klass.column_names.map(&:to_sym)

--- a/lib/blueprinter/serializers/auto_serializer.rb
+++ b/lib/blueprinter/serializers/auto_serializer.rb
@@ -1,0 +1,8 @@
+module Blueprinter
+  class AutoSerializer < Blueprinter::Serializer
+    def serialize(field_name, object, local_options, options = {})
+      serializer = object.is_a?(Hash) ? HashSerializer : PublicSendSerializer
+      serializer.serialize(field_name, object, local_options, options = {})
+    end
+  end
+end

--- a/lib/blueprinter/serializers/hash_serializer.rb
+++ b/lib/blueprinter/serializers/hash_serializer.rb
@@ -1,0 +1,5 @@
+class Blueprinter::HashSerializer < Blueprinter::Serializer
+  def serialize(field_name, object, local_options, options = {})
+    object[field_name] || object[field_name.to_s]
+  end
+end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -6,27 +6,64 @@ require_relative '../factories/model_factories.rb'
 describe '::Base' do
   describe '::render' do
     subject { blueprint.render(obj) }
+    let(:blueprint_with_block) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :position_and_company do |obj|
+          "#{obj.position} at #{obj.company}"
+        end
+      end
+    end
 
     context 'Outside Rails project' do
-      let(:obj_hash) do
-        {
-          id: 1,
-          first_name: 'Meg',
-          last_name: 'Ryan',
-          position: 'Manager',
-          description: 'A person',
-          company: 'Procore'
-        }
-      end
-      let(:obj) { OpenStruct.new(obj_hash) }
-      let(:vehicle) { OpenStruct.new(id: 1, make: 'Super Car') }
+      context 'Given passed object has dot notation accessible attributes' do
+        let(:obj_hash) do
+          {
+            id: 1,
+            first_name: 'Meg',
+            last_name: 'Ryan',
+            position: 'Manager',
+            description: 'A person',
+            company: 'Procore'
+          }
+        end
+        let(:obj) { OpenStruct.new(obj_hash) }
+        let(:obj_id) { obj.id.to_s }
+        let(:vehicle) { OpenStruct.new(id: 1, make: 'Super Car') }
 
-      include_examples 'Base::render'
+        include_examples 'Base::render'
+      end
+
+      context 'Given passed object is a Hash' do
+        let(:obj) do
+          {
+            id: 1,
+            first_name: 'Meg',
+            last_name: 'Ryan',
+            position: 'Manager',
+            description: 'A person',
+            company: 'Procore'
+          }
+        end
+        let(:vehicle) { { id: 1, make: 'Super Car' } }
+        let(:obj_id) { obj[:id].to_s }
+        let(:blueprint_with_block) do
+          Class.new(Blueprinter::Base) do
+            identifier :id
+            field :position_and_company do |obj|
+              "#{obj[:position]} at #{obj[:company]}"
+            end
+          end
+        end
+
+        include_examples 'Base::render'
+      end
     end
 
     context 'Inside Rails project' do
       include FactoryGirl::Syntax::Methods
       let(:obj) { create(:user) }
+      let(:obj_id) { obj.id.to_s }
       let(:vehicle) { create(:vehicle) }
 
       include_examples 'Base::render'

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -1,6 +1,4 @@
 shared_examples 'Base::render' do
-  let(:obj_id) { obj.id.to_s }
-
   context 'Given blueprint has ::field' do
     let(:result) { '{"first_name":"Meg","id":' + obj_id + '}' }
     let(:blueprint) do
@@ -41,7 +39,7 @@ shared_examples 'Base::render' do
     let(:blueprint) do
       serializer = Class.new(Blueprinter::Serializer) do
         def serialize(field_name, object, _local_options, _options={})
-          object.public_send(field_name).upcase
+          object[field_name].upcase
         end
       end
       Class.new(Blueprinter::Base) do
@@ -91,14 +89,7 @@ shared_examples 'Base::render' do
 
   context 'Given blueprint has ::field with a block' do
     let(:result) { '{"id":' + obj_id + ',"position_and_company":"Manager at Procore"}' }
-    let(:blueprint) do
-      Class.new(Blueprinter::Base) do
-        identifier :id
-        field :position_and_company do |obj|
-          "#{obj.position} at #{obj.company}"
-        end
-      end
-    end
+    let(:blueprint) { blueprint_with_block }
     it('returns json with values derived from a block') { should eq(result) }
   end
 
@@ -109,7 +100,7 @@ shared_examples 'Base::render' do
       Class.new(Blueprinter::Base) do
         identifier :id
         field :vehicle_make do |_obj, options|
-          "#{options[:vehicle].make}"
+          "#{options[:vehicle][:make]}"
         end
       end
     end


### PR DESCRIPTION
Support Hash by using AutoSerializer as default

AutoSerializer will delegate between HashSerializer to serialize
Hash objects or to PublicSendSerializer to serialize objects with
dot notation attributes.

We also don't iterate over all objects that respond to `:map` anymore
because `Hash` responds to `:map`, but we wouldn't want that. So we
have to be more specific on what objects we treat like an array.
    
In the process of creating new serializers, I noticed that the Base class seems to know about Field and the Serializer class way too much. So I move the responsibility of invoking
the serializer to the Field. This actually resolves #43.