### PR TITLE
Change 'block.call to yield'

### DIFF
--- a/spec/benchmarks/benchmark_helper.rb
+++ b/spec/benchmarks/benchmark_helper.rb
@@ -7,7 +7,7 @@ module BenchmarkHelper
     start = Time.now
     count = 0
     while Time.now - start <= 1.second do
-      block.call
+      yield
       count += 1
     end
     count

--- a/spec/benchmarks/benchmark_helper.rb
+++ b/spec/benchmarks/benchmark_helper.rb
@@ -3,7 +3,7 @@ require "rails/test_help"
 Rails::TestUnitReporter.executable = 'bin/test'
 
 module BenchmarkHelper
-  def iterate(&block)
+  def iterate
     start = Time.now
     count = 0
     while Time.now - start <= 1.second do


### PR DESCRIPTION
Past benchmark tests have shown that block.call is almost two times
slower than yield in older versions of Ruby.