### PR TITLE
Provides alias to reduce method name repetitions per issue #67

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -131,6 +131,10 @@ module Blueprinter
       jsonify(prepare(object, view_name: view_name, local_options: options))
     end
 
+    class << self
+      alias_method :print, :render
+    end
+
     # This is the magic method that converts complex objects into a simple hash
     # ready for JSON conversion.
     #


### PR DESCRIPTION
I used a metaclass to provide an alias for the render method per issue #67. 