### PR TITLE
Accept an option 'default' to allow setting default serialized value for association if null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0  - 2018/05/15
+
+* [FEATURE] Add `default` option to `association` which will be used as the serialized value instead of `null` when the association evaluates to null.
+See PR #78 by @vinaya-procore.
+
 ## 0.4.0  - 2018/05/02
 
 * [FEATURE] Add `render_as_hash` which will output a hash instead of

--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ Output:
 }
 ```
 
+#### Default option
+By default, an association that evaluates to `nil` is serialized as `nil`. A default serialized value can be
+specified as option on the association for cases when the association could potentially evaluate to `nil`.
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+
+  view :normal do
+    fields :first_name, :last_name
+    association :company, blueprint: CompanyBlueprint, default: {}
+  end
+end
+```
+
 ### Defining a field directly in the Blueprint
 
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. For example:

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,8 +1,8 @@
 module Blueprinter
   class AssociationExtractor < Extractor
     def extract(association_name, object, local_options, options={})
-      value = object.public_send(association_name) || options[:default]
-      return value if value.blank?
+      value = object.public_send(association_name)
+      return (value || options[:default]) if value.nil?
       view = options[:view] || :default
       options[:blueprint].prepare(value, view_name: view, local_options: local_options)
     end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,8 +1,8 @@
 module Blueprinter
   class AssociationExtractor < Extractor
     def extract(association_name, object, local_options, options={})
-      value = object.public_send(association_name)
-      return value if value.nil?
+      value = object.public_send(association_name) || options[:default]
+      return value if value.blank?
       view = options[:view] || :default
       options[:blueprint].prepare(value, view_name: view, local_options: local_options)
     end

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -94,6 +94,40 @@ describe '::Base' do
           it { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
         end
       end
+
+      context "Given association is nil" do
+        before do
+          expect(vehicle).to receive(:user).and_return(nil)
+        end
+
+        context "Given default association value is not provided" do
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              fields :make
+              association :user, blueprint: Class.new(Blueprinter::Base) { identifier :id }
+            end
+          end
+
+          it "should render the association as nil" do
+            expect(JSON.parse(blueprint.render(vehicle))["user"]).to be_nil
+          end
+        end
+
+        context "Given default association value is provided" do
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              fields :make
+              association :user,
+                blueprint: Class.new(Blueprinter::Base) { identifier :id },
+                default: {}
+            end
+          end
+
+          it "should render the default value provided for the association" do
+            expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq({})
+          end
+        end
+      end
     end
   end
   describe '::render_as_hash' do


### PR DESCRIPTION
**Included in the PR**

For models that have `belongs_to` association that allow `null` relationship, blueprinter serializes to `null` by default. This PR adds an ability to add a `default` option to blueprinter association which can be used as the serialized value instead of null.

In cases when the association `company` is `nil`, the behavior looks as follows:

**Before**
```ruby
class UserBlueprint < Blueprinter::Base
    identifier :uuid
    association :company, blueprint: CompanyBlueprint
end
```

`UserBlueprint.render(user)` renders `{ "id": 1, "company": null }`

**After**
```ruby
class UserBlueprint < Blueprinter::Base
    identifier :uuid
    association :company, blueprint: CompanyBlueprint, default: {}
end
```

`UserBlueprint.render(user)` renders `{ "id": 1, "company": {} }`

