### PR TITLE
Fix options param passing to extract method

### DIFF
--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -2,7 +2,7 @@ module Blueprinter
   class AutoExtractor < Extractor
     def extract(field_name, object, local_options, options = {})
       extractor = object.is_a?(Hash) ? HashExtractor : PublicSendExtractor
-      extractor.extract(field_name, object, local_options, options = {})
+      extractor.extract(field_name, object, local_options, options)
     end
   end
 end


### PR DESCRIPTION
When calling `extractor.extract` from `AutoExtractor` the options param is accidentally wiped out. This PR fixes the method call to ensure the options are properly passed on.