### PR TITLE
Add custom date and time formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And the output would look like:
 ```
 
 ### Views
-You may define different ouputs by utilizing views:
+You may define different outputs by utilizing views:
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid

--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ Output:
 }
 ```
 
+### Custom formatting for dates and times
+To define a custom format for a Date or DateTime field, include the option `datetime_format` with the associated `strptime` format.
+
+Usage:
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :name
+  field :birthday, datetime_format: "%m/%d/%Y"
+end
+```
+
+Output:
+```json
+{
+  "name": "John Doe",
+  "birthday": "03/04/1994"
+}
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -6,7 +6,6 @@ require_relative 'extractors/auto_extractor'
 require_relative 'extractors/block_extractor'
 require_relative 'extractors/hash_extractor'
 require_relative 'extractors/public_send_extractor'
-require_relative 'extractors/datetime_extractor'
 require_relative 'field'
 require_relative 'view'
 require_relative 'view_collection'
@@ -25,7 +24,7 @@ module Blueprinter
     #   want to set for serialization.
     # @param name [Symbol] to rename the identifier key in the JSON
     #   output. Defaults to method given.
-    # @param extractor [AssociationExtractor,AutoExtractor,BlockExtractor,HashExtractor,PublicSendExtractor,DateTimeExtractor]
+    # @param extractor [AssociationExtractor,AutoExtractor,BlockExtractor,HashExtractor,PublicSendExtractor]
     #   Kind of extractor to use.
     #   Either define your own or use Blueprinter's premade extractors.
     #   Defaults to AutoExtractor
@@ -47,7 +46,7 @@ module Blueprinter
     # @param method [Symbol] the field or method name you want to include for
     #   serialization.
     # @param options [Hash] options to overide defaults.
-    # @option options [AssociationExtractor,BlockExtractor,HashExtractor,PublicSendExtractor,DateTimeExtractor] :extractor
+    # @option options [AssociationExtractor,BlockExtractor,HashExtractor,PublicSendExtractor] :extractor
     #   Kind of extractor to use.
     #   Either define your own or use Blueprinter's premade extractors. The
     #   Default extractor is AutoExtractor

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -53,6 +53,8 @@ module Blueprinter
     # @option options [Symbol] :name Use this to rename the method. Useful if
     #   if you want your JSON key named differently in the output than your
     #   object's field or method name.
+    # @option options [String] :datetime_format Format Date or DateTime object
+    #   with given strftime formatting
     # @yield [Object] The object passed to `render` is also passed to the
     #   block.
     #

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -6,6 +6,7 @@ require_relative 'extractors/auto_extractor'
 require_relative 'extractors/block_extractor'
 require_relative 'extractors/hash_extractor'
 require_relative 'extractors/public_send_extractor'
+require_relative 'extractors/datetime_extractor'
 require_relative 'field'
 require_relative 'view'
 require_relative 'view_collection'
@@ -24,7 +25,7 @@ module Blueprinter
     #   want to set for serialization.
     # @param name [Symbol] to rename the identifier key in the JSON
     #   output. Defaults to method given.
-    # @param extractor [AssociationExtractor,AutoExtractor,BlockExtractor,HashExtractor,PublicSendExtractor]
+    # @param extractor [AssociationExtractor,AutoExtractor,BlockExtractor,HashExtractor,PublicSendExtractor,DateTimeExtractor]
     #   Kind of extractor to use.
     #   Either define your own or use Blueprinter's premade extractors.
     #   Defaults to AutoExtractor
@@ -46,7 +47,7 @@ module Blueprinter
     # @param method [Symbol] the field or method name you want to include for
     #   serialization.
     # @param options [Hash] options to overide defaults.
-    # @option options [AssociationExtractor,BlockExtractor,HashExtractor,PublicSendExtractor] :extractor
+    # @option options [AssociationExtractor,BlockExtractor,HashExtractor,PublicSendExtractor,DateTimeExtractor] :extractor
     #   Kind of extractor to use.
     #   Either define your own or use Blueprinter's premade extractors. The
     #   Default extractor is AutoExtractor

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -3,7 +3,15 @@ module Blueprinter
     def extract(field_name, object, local_options, options = {})
       extractor = object.is_a?(Hash) ? HashExtractor : PublicSendExtractor
       extraction = extractor.extract(field_name, object, local_options, options)
-      options.key?(:datetime_format) ? extraction.strftime(options[:datetime_format]) : extraction
+      options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
+    end
+
+    private
+
+    def format_datetime(datetime, format)
+      datetime.strftime(format)
+    rescue NoMethodError
+      raise BlueprinterError, 'Cannot format invalid DateTime object'
     end
   end
 end

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -1,15 +1,9 @@
 module Blueprinter
   class AutoExtractor < Extractor
     def extract(field_name, object, local_options, options = {})
-      extractor =
-        if object.is_a?(Hash)
-          HashExtractor
-        elsif options.key?(:datetime_format)
-          DateTimeExtractor
-        else
-          PublicSendExtractor
-        end
-      extractor.extract(field_name, object, local_options, options)
+      extractor = object.is_a?(Hash) ? HashExtractor : PublicSendExtractor
+      extraction = extractor.extract(field_name, object, local_options, options)
+      options.key?(:datetime_format) ? extraction.strftime(options[:datetime_format]) : extraction
     end
   end
 end

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -1,7 +1,14 @@
 module Blueprinter
   class AutoExtractor < Extractor
     def extract(field_name, object, local_options, options = {})
-      extractor = object.is_a?(Hash) ? HashExtractor : PublicSendExtractor
+      extractor =
+        if object.is_a?(Hash)
+          HashExtractor
+        elsif options.key?(:datetime_format)
+          DateTimeExtractor
+        else
+          PublicSendExtractor
+        end
       extractor.extract(field_name, object, local_options, options)
     end
   end

--- a/lib/blueprinter/extractors/datetime_extractor.rb
+++ b/lib/blueprinter/extractors/datetime_extractor.rb
@@ -1,8 +1,0 @@
-module Blueprinter
-  class DateTimeExtractor < Extractor
-    def extract(field_name, object, local_options, options = {})
-      datetime = object.public_send(field_name)
-      datetime.strftime(options[:datetime_format])
-    end
-  end
-end

--- a/lib/blueprinter/extractors/datetime_extractor.rb
+++ b/lib/blueprinter/extractors/datetime_extractor.rb
@@ -1,0 +1,8 @@
+module Blueprinter
+  class DateTimeExtractor < Extractor
+    def extract(field_name, object, local_options, options = {})
+      datetime = object.public_send(field_name)
+      datetime.strftime(options[:datetime_format])
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define(version: 20170830212110) do
     t.string "last_name"
     t.string "email"
     t.text "address"
+    t.datetime "birthday"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/model_factories.rb
+++ b/spec/factories/model_factories.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     position 'Manager'
     description 'A person'
     company 'Procore'
+    birthday Date.new(1994, 3, 4)
   end
 
   factory :vehicle do

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -19,7 +19,8 @@ describe '::Base' do
       last_name: 'Ryan',
       position: 'Manager',
       description: 'A person',
-      company: 'Procore'
+      company: 'Procore',
+      birthday: Date.new(1994, 3, 4)
     }
   end
   let(:object_with_attributes) { OpenStruct.new(obj_hash) }

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -63,6 +63,16 @@ shared_examples 'Base::render' do
     it('returns json with a formatted field') { should eq(result) }
   end
 
+  context 'Given blueprint has a :datetime_format argument on an invalid ::field' do
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :first_name, datetime_format: "%m/%d/%Y"
+      end
+    end
+    it('raises a BlueprinterError') { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
+  end
+
   context 'Given blueprint has ::view' do
     let(:normal) do
       ['{"id":' + obj_id + '', '"employer":"Procore"', '"first_name":"Meg"',

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -50,6 +50,19 @@ shared_examples 'Base::render' do
     it('returns json derived from a custom extractor') { should eq(result) }
   end
 
+  context 'Given blueprint has ::field with a :datetime_format argument' do
+    let(:result) do
+      '{"id":' + obj_id + ',"birthday":"03/04/1994"}'
+    end
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :birthday, datetime_format: "%m/%d/%Y"
+      end
+    end
+    it('returns json with a formatted field') { should eq(result) }
+  end
+
   context 'Given blueprint has ::view' do
     let(:normal) do
       ['{"id":' + obj_id + '', '"employer":"Procore"', '"first_name":"Meg"',


### PR DESCRIPTION
Blueprinter needs a mechanism to specify custom serialization for Date and DateTime fields.

To define a custom format for a Date or DateTime field, include the option `datetime_format` with the associated `strptime` format.

Usage:
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :name
  field :birthday, datetime_format: "%m/%d/%Y"
end
```

Output:
```json
{
  "name": "John Doe",
  "birthday": "03/04/1994"
}
```