### PR TITLE
Add conditional fields support

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -37,7 +37,7 @@ module Blueprinter
     #
     # @return [Field] A Field object
     def self.identifier(method, name: method, extractor: AutoExtractor)
-      view_collection[:identifier] << Field.new(method, name, extractor)
+      view_collection[:identifier] << Field.new(method, name, extractor, self)
     end
 
     # Specify a field or method name to be included for serialization.
@@ -53,6 +53,14 @@ module Blueprinter
     # @option options [Symbol] :name Use this to rename the method. Useful if
     #   if you want your JSON key named differently in the output than your
     #   object's field or method name.
+    # @option options [Symbol,Proc] :if Specifies a method, proc or string to
+    #   call to determine if the field should be included (e.g.
+    #   `if: :include_first_name?, or if: Proc.new { |user, options| options[:current_user] == user }).
+    #   The method, proc or string should return or evaluate to a true or false value.
+    # @option options [Symbol,Proc] :unless Specifies a method, proc or string
+    #   to call to determine if the field should be included (e.g.
+    #   `unless: :include_first_name?, or unless: Proc.new { |user, options| options[:current_user] != user }).
+    #   The method, proc or string should return or evaluate to a true or false value.
     # @yield [Object] The object passed to `render` is also passed to the
     #   block.
     #
@@ -68,6 +76,17 @@ module Blueprinter
     #     # other code
     #   end
     #
+    # @example Passing an if proc and unless method..
+    #   class UserBlueprint < Blueprinter::Base
+    #     def skip_first_name?(user, options)
+    #       user.first_name == options[:first_name]
+    #     end
+    #
+    #     field :first_name, unless: :skip_first_name?
+    #     field :last_name, if: ->(user, options) { user.first_name != options[:first_name] }
+    #     # other code
+    #   end
+    #
     # @return [Field] A Field object
     def self.field(method, options = {}, &block)
       options = if block_given?
@@ -78,6 +97,7 @@ module Blueprinter
       current_view << Field.new(method,
                                 options[:name],
                                 options[:extractor],
+                                self,
                                 options)
     end
 
@@ -107,6 +127,7 @@ module Blueprinter
       current_view << Field.new(method,
                                        name,
                                        AssociationExtractor,
+                                       self,
                                        options.merge(association: true))
     end
 
@@ -193,7 +214,7 @@ module Blueprinter
     # @return [Array<Symbol>] an array of field names
     def self.fields(*field_names)
       field_names.each do |field_name|
-        current_view << Field.new(field_name, field_name, AutoExtractor)
+        current_view << Field.new(field_name, field_name, AutoExtractor, self)
       end
     end
 
@@ -270,6 +291,7 @@ module Blueprinter
 
     def self.object_to_hash(object, view_name:, local_options:)
       view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
+        next if field.skip?(object, local_options)
         hash[field.name] = field.extract(object, local_options)
       end
     end

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -1,14 +1,44 @@
 # @api private
 class Blueprinter::Field
-  attr_reader :method, :name, :extractor, :options
-  def initialize(method, name, extractor, options = {})
+  attr_reader :method, :name, :extractor, :options, :blueprint
+  def initialize(method, name, extractor, blueprint, options = {})
     @method = method
     @name = name
     @extractor = extractor
+    @blueprint = blueprint
     @options = options
   end
 
   def extract(object, local_options)
     extractor.extract(method, object, local_options, options)
+  end
+
+  def skip?(object, local_options)
+    return true if if_callable && !if_callable.call(object, local_options)
+    unless_callable && unless_callable.call(object, local_options)
+  end
+
+  private
+
+  def if_callable
+    return @if_callable unless @if_callable.nil?
+    @if_callable ||= callable_from(:if)
+  end
+
+  def unless_callable
+    return @unless_callable unless @unless_callable.nil?
+    @unless_callable ||= callable_from(:unless)
+  end
+
+  def callable_from(option_name)
+    return false unless options.key?(option_name)
+
+    tmp = options.fetch(option_name)
+    case tmp
+    when Proc then tmp
+    when Symbol then blueprint.method(tmp)
+    else
+      raise ArgumentError, "#{tmp.class} is passed to :#{option_name}"
+    end
   end
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -50,6 +50,100 @@ shared_examples 'Base::render' do
     it('returns json derived from a custom extractor') { should eq(result) }
   end
 
+  context 'Given blueprint has ::field with a conditional argument' do
+    variants = %i[proc method].product([true, false])
+
+    let(:if_value) { true }
+    let(:unless_value) { false }
+    let(:field_options) { {} }
+    let(:local_options) { { x: 1, y: 2 } }
+    let(:if_proc) { ->(_obj, _local_opts) { if_value } }
+    let(:unless_proc) { ->(_obj, _local_opts) { unless_value } }
+    let(:blueprint) do
+      f_options = field_options
+
+      bp = Class.new(Blueprinter::Base) do
+        field :id
+        field :first_name, f_options
+      end
+      bp.instance_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def self.if_method(_object, _options)
+              #{if_value}
+            end
+
+            def self.unless_method(_object, _options)
+              #{unless_value}
+            end
+          RUBY
+      bp
+    end
+    let(:result_with_first_name) do
+      %({"first_name":"Meg","id":#{obj_id}})
+    end
+    let(:result_without_first_name) { %({"id":#{obj_id}}) }
+    subject { blueprint.render(obj, local_options) }
+
+    shared_examples 'serializes the conditional field' do
+      it 'serializes the conditional field' do
+        should eq(result_with_first_name)
+      end
+    end
+
+    shared_examples 'does not serialize the conditional field' do
+      it 'does not serialize the conditional field' do
+        should eq(result_without_first_name)
+      end
+    end
+
+    variants.each do |type, value|
+      context "Given the conditional is :if #{type} returning #{value}" do
+        let(:if_value) { value }
+
+        before do
+          field_options[:if] = type == :method ? :if_method : if_proc
+        end
+
+        context 'and no :unless conditional' do
+          if value
+            include_examples 'serializes the conditional field'
+          else
+            include_examples 'does not serialize the conditional field'
+          end
+        end
+
+        variants.each do |other_type, other_value|
+          context "and :unless conditional is #{other_type} returning #{other_value}" do
+            let(:unless_value) { other_value }
+            before do
+              field_options[:unless] = if type == :method then :unless_method
+                                       else unless_proc
+                                       end
+            end
+
+            if value && !other_value
+              include_examples 'serializes the conditional field'
+            else
+              include_examples 'does not serialize the conditional field'
+            end
+          end
+        end
+      end
+
+      context "Given the conditional is :unless #{type} returning #{value} and no :if conditional" do
+        let(:unless_value) { value }
+        before do
+          field_options[:unless] = type == :method ? :unless_method : unless_proc
+        end
+
+        if value
+          include_examples 'does not serialize the conditional field'
+        else
+          include_examples 'serializes the conditional field'
+        end
+      end
+    end
+  end
+
   context 'Given blueprint has ::view' do
     let(:normal) do
       ['{"id":' + obj_id + '', '"employer":"Procore"', '"first_name":"Meg"',


### PR DESCRIPTION
See https://github.com/procore/blueprinter/issues/81
One omission: methods should be declared before field declaration using them, i. e.
```ruby
class UserBlueprinter < Blueprinter::Base
  # field :first_name, if: :my_method here will fail
  def my_method(user, options)
    # some code
  end

  field :first_name, if: :my_method
end
```
because methods are not available yet at field declaration time and I'm resolving Symbol to Method there. Is it worth fixing or I should just add a note to README?

Other one: AFAICS collection serialization is not tested at the moment, so I also skipped it. 