### PR TITLE
Circleci ruby test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ steps: &steps_spec
       command: bundle exec rake benchmarks
 
 jobs:
-  ruby-2.2:
+  ruby-2.2.10:
     steps: *steps_spec
     docker:
-      - image: ruby:2.2
+      - image: ruby:2.2.10
   ruby-2.3:
     steps: *steps_spec
     docker:
@@ -33,7 +33,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - ruby-2.2
+      - ruby-2.2.10
       - ruby-2.3
       - ruby-2.4
       - ruby-2.5

--- a/spec/benchmarks/big_o_test.rb
+++ b/spec/benchmarks/big_o_test.rb
@@ -13,7 +13,7 @@ class Blueprinter::BigOTest < Minitest::Benchmark
   end
 
   def bench_render_basic
-    assert_performance_linear(0.98) do |n|
+    assert_performance_linear do |n|
       @blueprinter.render(@prepared_objects[n])
     end
   end


### PR DESCRIPTION
Ruby 2.2.0 has severe memory leak problems, which could be the reason
why it is regularly failing the linear benchmark test.

See https://bugs.ruby-lang.org/issues/10686

The next closest 2.2.x official ruby docker image is 2.2.10, so using
2.2.10 instead.