### PR TITLE
Inherit view definition when using inheritance

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -41,6 +41,10 @@ module Blueprinter
       view_collection[:identifier] << Field.new(method, name, extractor, self)
     end
 
+    def self.inherited(subclass)
+      subclass.send(:view_collection).inherit(view_collection)
+    end
+
     # Specify a field or method name to be included for serialization.
     # Takes a required method and an option.
     #

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -33,10 +33,6 @@ module Blueprinter
     end
 
     def <<(field)
-      if fields.has_key?(field.name)
-        raise BlueprinterError,
-          "Field #{field.name} already defined on #{name}"
-      end
       fields[field.name] = field
     end
   end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -10,6 +10,20 @@ module Blueprinter
       @excluded_field_names = excluded_view_names
     end
 
+    def inherit(view)
+      view.fields.values.each do |field|
+        self << field
+      end
+
+      view.included_view_names.each do |view_name|
+        include_view(view_name)
+      end
+
+      view.excluded_field_names.each do |field_name|
+        exclude_field(field_name)
+      end
+    end
+
     def include_view(view_name)
       included_view_names << view_name
     end

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -9,6 +9,12 @@ module Blueprinter
       }
     end
 
+    def inherit(view_collection)
+      view_collection.views.each do |view_name, view|
+        self[view_name].inherit(view)
+      end
+    end
+
     def has_view?(view_name)
       views.has_key? view_name
     end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -141,4 +141,61 @@ describe '::Base' do
       end
     end
   end
+
+  describe 'Using the ApplicationBlueprint pattern' do
+    let(:obj) { OpenStruct.new(id: 1, name: 'Meg', age: 32) }
+    let(:application_blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :name
+
+        view :with_age do
+          field :age
+        end
+
+        view :anonymous_age do
+          include_view :with_age
+          exclude :name
+        end
+      end
+    end
+
+    let(:blueprint) do
+      Class.new(application_blueprint) do
+        view :only_age do
+          include_view :with_age
+          exclude :name
+        end
+      end
+    end
+
+    subject { blueprint.render_as_hash(obj) }
+
+    it('inherits identifier') { expect(subject[:id]).to eq(obj.id) }
+    it('inherits field') { expect(subject[:name]).to eq(obj.name) }
+
+    describe 'Inheriting views' do
+      let(:view) { :with_age }
+      subject { blueprint.render_as_hash(obj, view: view) }
+
+      it('includes identifier') { expect(subject[:id]).to eq(obj.id) }
+      it('includes base fields') { expect(subject[:name]).to eq(obj.name) }
+      it('includes view fields') { expect(subject[:age]).to eq(obj.age) }
+
+      describe 'With complex views' do
+        let(:view) { :anonymous_age }
+
+        it('includes identifier') { expect(subject[:id]).to eq(obj.id) }
+        it('includes include_view fields') { expect(subject[:age]).to eq(obj.age) }
+        it('excludes excluded fields') { expect(subject).to_not have_key(:name) }
+      end
+
+      describe 'Referencing views from parent blueprint' do
+        let(:view) { :only_age }
+
+        it('includes include_view fields') { expect(subject[:age]).to eq(obj.age) }
+        it('excludes excluded fields') { expect(subject).not_to have_key(:name) }
+      end
+    end
+  end
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -148,6 +148,7 @@ describe '::Base' do
       Class.new(Blueprinter::Base) do
         identifier :id
         field :name
+        field(:overridable) { |o| o.name }
 
         view :with_age do
           field :age
@@ -162,6 +163,8 @@ describe '::Base' do
 
     let(:blueprint) do
       Class.new(application_blueprint) do
+        field(:overridable) { |o| o.age }
+
         view :only_age do
           include_view :with_age
           exclude :name
@@ -173,6 +176,7 @@ describe '::Base' do
 
     it('inherits identifier') { expect(subject[:id]).to eq(obj.id) }
     it('inherits field') { expect(subject[:name]).to eq(obj.name) }
+    it('overrides field definition') { expect(subject[:overridable]).to eq(obj.age) }
 
     describe 'Inheriting views' do
       let(:view) { :with_age }

--- a/spec/units/view_spec.rb
+++ b/spec/units/view_spec.rb
@@ -33,10 +33,14 @@ describe '::View' do
     end
 
     context 'Given a field that already exists' do
+      let(:aliased_field) { MockField.new(:fname, :first_name) }
+
       before { view << field }
-      it { expect { view << field }.to raise_error(blueprinter_error) }
-      it 'should not set #fields' do
-        expect(view.fields).to eq({first_name: field})
+
+      it 'overrides previous definition' do
+        view << aliased_field
+
+        expect(view.fields).to eq(first_name: aliased_field)
       end
     end
   end
@@ -56,8 +60,9 @@ describe '::View' do
 end
 
 class MockField
-  attr_reader :name
-  def initialize(name)
-    @name = name
+  attr_reader :name, :method
+  def initialize(method, name = nil)
+    @method = method
+    @name = name || method
   end
 end


### PR DESCRIPTION
Enable field and view definitions on superclasses
to be used by subclasses:

    class ApplicationBlueprint < Blueprinter::Base
      identifier :id
      field :created_at
    end

    class PersonBlueprint < ApplicationBlueprint
      fields :name, :age
    end

Objects rendered with `PersonBlueprint` will contain fields `id`,
`created_at`, `name`, and `age`.


(Addresses issue #80)