### PR TITLE
Allow associations to be defined with a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,44 @@ Output:
 }
 ```
 
+#### Defining an association directly in the Blueprint
+
+You can also pass a block to an association:
+
+```ruby
+class ProjectBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :name
+end
+
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+
+  association :projects, blueprint: ProjectBlueprint do |user|
+    user.projects + user.company.projects
+  end
+end
+```
+
+Usage:
+
+```ruby
+puts UserBlueprint.render(user)
+```
+
+Output:
+
+```json
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+  "projects": [
+    {"uuid": "b426a1e6-ac41-45ab-bfef-970b9a0b4289", "name": "query-console"},
+    {"uuid": "5bd84d6c-4fd2-4e36-ae31-c137e39be542", "name": "blueprinter"},
+    {"uuid": "785f5cd4-7d8d-4779-a6dd-ec5eab440eff", "name": "uncontrollable"}
+  ]
+}
+```
+
 ### Passing additional properties to `render`
 
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -97,7 +97,7 @@ module Blueprinter
     # @return [Field] A Field object
     def self.field(method, options = {}, &block)
       options = if block_given?
-        {name: method, extractor: BlockExtractor, block: {method => block}}
+        {name: method, extractor: BlockExtractor, block: block}
       else
         {name: method, extractor: AutoExtractor}
       end.merge(options)
@@ -128,14 +128,21 @@ module Blueprinter
     #   end
     #
     # @return [Field] A Field object
-    def self.association(method, options = {})
+    def self.association(method, options = {}, &block)
       raise BlueprinterError, 'blueprint required' unless options[:blueprint]
       name = options.delete(:name) || method
+
+      options = if block_given?
+        options.merge(extractor: BlockExtractor, block: block)
+      else
+        options.merge(extractor: AutoExtractor)
+      end
+
       current_view << Field.new(method,
-                                       name,
-                                       AssociationExtractor,
-                                       self,
-                                       options.merge(association: true))
+                                name,
+                                AssociationExtractor.new(options[:extractor]),
+                                self,
+                                options.merge(association: true))
     end
 
     # Generates a JSON formatted String.

--- a/lib/blueprinter/extractor.rb
+++ b/lib/blueprinter/extractor.rb
@@ -1,9 +1,6 @@
 # @api private
 module Blueprinter
   class Extractor
-    def initialize
-    end
-
     def extract(field_name, object, local_options, options={})
       fail NotImplementedError, "An Extractor must implement #extract"
     end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,11 +1,7 @@
 module Blueprinter
   class AssociationExtractor < Extractor
-    def initialize(field_extractor)
-      @field_extractor = field_extractor
-    end
-
     def extract(association_name, object, local_options, options={})
-      value = @field_extractor.extract(association_name, object, local_options, options)
+      value = options[:extractor].extract(association_name, object, local_options, options)
       return options[:default] if value.nil?
       view = options[:view] || :default
       options[:blueprint].prepare(value, view_name: view, local_options: local_options)

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,8 +1,12 @@
 module Blueprinter
   class AssociationExtractor < Extractor
+    def initialize(field_extractor)
+      @field_extractor = field_extractor
+    end
+
     def extract(association_name, object, local_options, options={})
-      value = object.public_send(association_name)
-      return (value || options[:default]) if value.nil?
+      value = @field_extractor.extract(association_name, object, local_options, options)
+      return options[:default] if value.nil?
       view = options[:view] || :default
       options[:blueprint].prepare(value, view_name: view, local_options: local_options)
     end

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -1,7 +1,12 @@
 module Blueprinter
   class AutoExtractor < Extractor
+    def initialize
+      @hash_extractor = HashExtractor.new
+      @public_send_extractor = PublicSendExtractor.new
+    end
+
     def extract(field_name, object, local_options, options = {})
-      extractor = object.is_a?(Hash) ? HashExtractor : PublicSendExtractor
+      extractor = object.is_a?(Hash) ? @hash_extractor : @public_send_extractor
       extraction = extractor.extract(field_name, object, local_options, options)
       options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
     end

--- a/lib/blueprinter/extractors/block_extractor.rb
+++ b/lib/blueprinter/extractors/block_extractor.rb
@@ -1,7 +1,7 @@
 module Blueprinter
   class BlockExtractor < Extractor
     def extract(field_name, object, local_options, options = {})
-      options[:block][field_name].call(object, local_options)
+      options[:block].call(object, local_options)
     end
   end
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -84,6 +84,22 @@ describe '::Base' do
           end
           it('returns json with association') { should eq(result) }
         end
+        context 'Given block is passed' do
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              fields :make
+            end
+
+            Class.new(Blueprinter::Base) do
+              identifier :id
+              association(:automobiles, blueprint: vehicle_blueprint) { |o| o.vehicles }
+            end
+          end
+          let(:result) do
+            '{"id":' + obj_id + ',"automobiles":[{"make":"Super Car"}]}'
+          end
+          it('returns json with aliased association') { should eq(result) }
+        end
         context 'Given no associated blueprint is given' do
           let(:blueprint) do
             Class.new(Blueprinter::Base) do


### PR DESCRIPTION
Addresses #90.

I removed an extra hash from `BlockExtractor`. Not sure if should have, but it seemed to be redundant, and tests are passing.

I changed `AssociationExtractor` so that it accepts a nested extractor. This allowed me to reuse `AutoExtractor` and `BlockExtractor`, making `#association` now very similar to `#field`.

I noticed that we're passing classes as extractors, and that the class method `extract` always creates a new instance of itself. This will probably create an unnecessary number of objects. Instantiating them directly in `#field` and `#association` might help improve performance. I addressed that in this PR as well.