### PR TITLE
Allow identifiers to be defined with a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,32 @@ Output:
 }
 ```
 
+#### Defining an identifier directly in the Blueprint
+
+You can also pass a block to an identifier:
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid do |user, options|
+    options[:current_user].anonymize(user.uuid)
+  end
+end
+```
+
+Usage:
+
+```ruby
+puts UserBlueprint.render(user, current_user: current_user)
+```
+
+Output:
+
+```json
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+}
+```
+
 #### Defining an association directly in the Blueprint
 
 You can also pass a block to an association:

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,7 +1,11 @@
 module Blueprinter
   class AssociationExtractor < Extractor
+    def initialize
+      @extractor = AutoExtractor.new
+    end
+
     def extract(association_name, object, local_options, options={})
-      value = options[:extractor].extract(association_name, object, local_options, options)
+      value = @extractor.extract(association_name, object, local_options, options)
       return options[:default] if value.nil?
       view = options[:view] || :default
       options[:blueprint].prepare(value, view_name: view, local_options: local_options)

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -3,15 +3,25 @@ module Blueprinter
     def initialize
       @hash_extractor = HashExtractor.new
       @public_send_extractor = PublicSendExtractor.new
+      @block_extractor = BlockExtractor.new
     end
 
     def extract(field_name, object, local_options, options = {})
-      extractor = object.is_a?(Hash) ? @hash_extractor : @public_send_extractor
-      extraction = extractor.extract(field_name, object, local_options, options)
+      extraction = extractor(object, options).extract(field_name, object, local_options, options)
       options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
     end
 
     private
+
+    def extractor(object, options)
+      if options[:block]
+        @block_extractor
+      elsif object.is_a?(Hash)
+        @hash_extractor
+      else
+        @public_send_extractor
+      end
+    end
 
     def format_datetime(datetime, format)
       datetime.strftime(format)

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -158,6 +158,34 @@ describe '::Base' do
     end
   end
 
+  describe 'identifier' do
+    let(:rendered) do
+      blueprint.render_as_hash(OpenStruct.new(uid: 42))
+    end
+
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :uid
+      end
+    end
+
+    it "renders identifier" do
+      expect(rendered).to eq(uid: 42)
+    end
+
+    describe 'Given a block is passed' do
+      let(:blueprint) do
+        Class.new(Blueprinter::Base) do
+          identifier(:id) { |object, _| object.uid * 2 }
+        end
+      end
+
+      it "renders result of block" do
+        expect(rendered).to eq(id: 84)
+      end
+    end
+  end
+
   describe 'Using the ApplicationBlueprint pattern' do
     let(:obj) { OpenStruct.new(id: 1, name: 'Meg', age: 32) }
     let(:application_blueprint) do


### PR DESCRIPTION
Now that `::association` and `::field` receive an optional block,
`::identifier` should receive it as well.

Since all three methods receive an optional block, the block extraction
mechanism was moved to `AutoExtractor`. Removing this mechanism from
each individual method made them very similar. `::association` now uses
`::field` instead of directly adding the field to the current view.

Addresses #109 