### PR TITLE
Localize private flag to class and not module

### DIFF
--- a/lib/blueprinter/extractor.rb
+++ b/lib/blueprinter/extractor.rb
@@ -1,5 +1,5 @@
-# @api private
 module Blueprinter
+  # @api private
   class Extractor
     def extract(field_name, object, local_options, options={})
       fail NotImplementedError, "An Extractor must implement #extract"


### PR DESCRIPTION
This private flag was accidentally placed at the top level module,
causing many methods and classes set at the top level to be considered
private when it shouldn't have been.

Take a look at https://www.rubydoc.info/gems/blueprinter/Blueprinter
it has the `configure` method as private, when it should be public.

Moving this private flag down to the Extractor class level should
fix this.