### PR TITLE
Accept an option 'default' to allow setting default serialized field value if null

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ Output:
 }
 ```
 
-#### Default option
-By default, an association that evaluates to `nil` is serialized as `nil`. A default serialized value can be
-specified as option on the association for cases when the association could potentially evaluate to `nil`.
+### Default Association/Field Option
+By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be
+specified as option on the association or field for cases when the association/field could potentially evaluate to `nil`.
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid
 
   view :normal do
-    fields :first_name, :last_name
+    field :first_name, default: "N/A"
     association :company, blueprint: CompanyBlueprint, default: {}
   end
 end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -5,15 +5,10 @@ module Blueprinter
     end
 
     def extract(association_name, object, local_options, options={})
-      if options.key?(:default)
-        value = @extractor.extract(association_name, object, local_options, options.except(:default))
-        return options[:default] if value.nil?
-      else
-        value = @extractor.extract(association_name, object, local_options, options)
-        return options[:default] if value.nil?
-        view = options[:view] || :default
-        options[:blueprint].prepare(value, view_name: view, local_options: local_options)
-      end
+      value = @extractor.extract(association_name, object, local_options, options.except(:default))
+      return options[:default] if value.nil?
+      view = options[:view] || :default
+      options[:blueprint].prepare(value, view_name: view, local_options: local_options)
     end
   end
 end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -5,10 +5,16 @@ module Blueprinter
     end
 
     def extract(association_name, object, local_options, options={})
-      value = @extractor.extract(association_name, object, local_options, options)
-      return options[:default] if value.nil?
-      view = options[:view] || :default
-      options[:blueprint].prepare(value, view_name: view, local_options: local_options)
+      if options.key?(:default)
+        default = options.delete(:default)
+        value = @extractor.extract(association_name, object, local_options, options)
+        return default if value.nil?
+      else
+        value = @extractor.extract(association_name, object, local_options, options)
+        return default if value.nil?
+        view = options[:view] || :default
+        options[:blueprint].prepare(value, view_name: view, local_options: local_options)
+      end
     end
   end
 end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -6,12 +6,11 @@ module Blueprinter
 
     def extract(association_name, object, local_options, options={})
       if options.key?(:default)
-        default = options.delete(:default)
-        value = @extractor.extract(association_name, object, local_options, options)
-        return default if value.nil?
+        value = @extractor.extract(association_name, object, local_options, options.except(:default))
+        return options[:default] if value.nil?
       else
         value = @extractor.extract(association_name, object, local_options, options)
-        return default if value.nil?
+        return options[:default] if value.nil?
         view = options[:view] || :default
         options[:blueprint].prepare(value, view_name: view, local_options: local_options)
       end

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -8,7 +8,8 @@ module Blueprinter
 
     def extract(field_name, object, local_options, options = {})
       extraction = extractor(object, options).extract(field_name, object, local_options, options)
-      options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
+      value = options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
+      value.nil? ? options[:default] : value
     end
 
     private

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -72,7 +72,37 @@ shared_examples 'Base::render' do
     end
     it('raises a BlueprinterError') { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
   end
-  
+
+  context "Given blueprint has ::field with nil value" do
+    before do
+      obj[:first_name] = nil
+    end
+
+    context "Given default value is not provided" do
+      let(:result) { '{"first_name":null,"id":' + obj_id + '}' }
+      let(:blueprint) do
+        Class.new(Blueprinter::Base) do
+          field :id
+          field :first_name
+        end
+      end
+      it('returns json with specified fields') { should eq(result) }
+    end
+
+    context "Given default value is provided" do
+      let(:result) { '{"first_name":"Unknown","id":' + obj_id + '}' }
+      let(:blueprint) do
+        Class.new(Blueprinter::Base) do
+          field :id
+          field :first_name, default: "Unknown"
+        end
+      end
+      it('returns json with specified fields') {
+        should eq(result)
+      }
+    end
+  end
+
   context 'Given blueprint has ::field with a conditional argument' do
     variants = %i[proc method].product([true, false])
 


### PR DESCRIPTION
**Included in the PR**

For fields that have a value of nil, blueprinter serializes to `null` by default. This PR adds an ability to add a `default` option to blueprinter fields which can be used as the serialized value instead of null.

**Before**
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :first_name
end
```

`UserBlueprint.render(user)` renders `{ "id": 1, "first_name": null }`

**After**
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :first_name, default: "N/A"
end
```

`UserBlueprint.render(user)` renders `{ "id": 1, "first_name": "N/A" }`

Aims to address: https://github.com/procore/blueprinter/issues/114