### PR TITLE
Add global default field/association value configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0  - 2019/1/16
+
+* 🚀 [FEATURE] Enables the setting of global `:field_default` and `:association_default` option value in the Blueprinter Configuration that will be used as default values for fields and associations that evaluate to nil. [#128](https://github.com/procore/blueprinter/pull/128). Thanks to [@mcclayton](https://github.com/mcclayton).
+
 ## 0.11.0  - 2019/1/15
 
 * 🚀 [FEATURE] Enables the setting of a global `:if`/`:unless` proc in the Blueprinter Configuration that will be used to evaluate the conditional render of all fields. [#127](https://github.com/procore/blueprinter/pull/127). Thanks to [@mcclayton](https://github.com/mcclayton).

--- a/README.md
+++ b/README.md
@@ -180,7 +180,17 @@ Output:
 ```
 
 ### Default Association/Field Option
-By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as option on the association or field for cases when the association/field could potentially evaluate to `nil`.
+By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
+
+#### Global Config Setting
+```ruby
+Blueprinter.configure do |config|
+  config.field_default = "N/A"
+  config.association_default = {}
+end
+```
+
+#### Field-level/Associaion-level Setting
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :uuid

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,10 +1,12 @@
 module Blueprinter
   class Configuration
-    attr_accessor :generator, :if, :method, :sort_fields_by, :unless
+    attr_accessor :association_default, :field_default, :generator, :if, :method, :sort_fields_by, :unless
 
     VALID_CALLABLES = %i(if unless)
 
     def initialize
+      @association_default = nil
+      @field_default = nil
       @generator = JSON
       @if = nil
       @method = :generate

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -14,8 +14,8 @@ module Blueprinter
 
     private
 
-    def default_value(field_options)
-      field_options.key?(:default) ? field_options.fetch(:default) : Blueprinter.configuration.association_default
+    def default_value(association_options)
+      association_options.key?(:default) ? association_options.fetch(:default) : Blueprinter.configuration.association_default
     end
 
     def association_blueprint(blueprint, value)

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -6,13 +6,17 @@ module Blueprinter
 
     def extract(association_name, object, local_options, options={})
       value = @extractor.extract(association_name, object, local_options, options.except(:default))
-      return options[:default] if value.nil?
+      return default_value(options) if value.nil?
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)
       blueprint.prepare(value, view_name: view, local_options: local_options)
     end
-    
+
     private
+
+    def default_value(field_options)
+      field_options.key?(:default) ? field_options.fetch(:default) : Blueprinter.configuration.association_default
+    end
 
     def association_blueprint(blueprint, value)
       blueprint.is_a?(Proc) ? blueprint.call(value) : blueprint

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -9,10 +9,14 @@ module Blueprinter
     def extract(field_name, object, local_options, options = {})
       extraction = extractor(object, options).extract(field_name, object, local_options, options)
       value = options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
-      value.nil? ? options[:default] : value
+      value.nil? ? default_value(options) : value
     end
 
     private
+
+    def default_value(field_options)
+      field_options.key?(:default) ? field_options.fetch(:default) : Blueprinter.configuration.field_default
+    end
 
     def extractor(object, options)
       if options[:block]

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -166,6 +166,21 @@ describe '::Base' do
               expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq({})
             end
           end
+
+          context "Given default association value is provided and is nil" do
+            let(:blueprint) do
+              Class.new(Blueprinter::Base) do
+                fields :make
+                association :user,
+                  blueprint: Class.new(Blueprinter::Base) { identifier :id },
+                  default: nil
+              end
+            end
+
+            it "should render the default value provided for the association" do
+              expect(JSON.parse(blueprint.render(vehicle))["user"]).to be_nil
+            end
+          end
         end
 
         context "Given global default association value is not specified" do

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -135,31 +135,66 @@ describe '::Base' do
           expect(vehicle).to receive(:user).and_return(nil)
         end
 
-        context "Given default association value is not provided" do
-          let(:blueprint) do
-            Class.new(Blueprinter::Base) do
-              fields :make
-              association :user, blueprint: Class.new(Blueprinter::Base) { identifier :id }
+        context "Given global default association value is specified" do
+          before { Blueprinter.configure { |config| config.association_default = "N/A" } }
+          after { reset_blueprinter_config! }
+
+          context "Given default association value is not provided" do
+            let(:blueprint) do
+              Class.new(Blueprinter::Base) do
+                fields :make
+                association :user, blueprint: Class.new(Blueprinter::Base) { identifier :id }
+              end
+            end
+
+            it "should render the association using the default global association value" do
+              expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq("N/A")
             end
           end
 
-          it "should render the association as nil" do
-            expect(JSON.parse(blueprint.render(vehicle))["user"]).to be_nil
+          context "Given default association value is provided" do
+            let(:blueprint) do
+              Class.new(Blueprinter::Base) do
+                fields :make
+                association :user,
+                  blueprint: Class.new(Blueprinter::Base) { identifier :id },
+                  default: {}
+              end
+            end
+
+            it "should render the default value provided for the association" do
+              expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq({})
+            end
           end
         end
 
-        context "Given default association value is provided" do
-          let(:blueprint) do
-            Class.new(Blueprinter::Base) do
-              fields :make
-              association :user,
-                blueprint: Class.new(Blueprinter::Base) { identifier :id },
-                default: {}
+        context "Given global default association value is not specified" do
+          context "Given default association value is not provided" do
+            let(:blueprint) do
+              Class.new(Blueprinter::Base) do
+                fields :make
+                association :user, blueprint: Class.new(Blueprinter::Base) { identifier :id }
+              end
+            end
+
+            it "should render the association as nil" do
+              expect(JSON.parse(blueprint.render(vehicle))["user"]).to be_nil
             end
           end
 
-          it "should render the default value provided for the association" do
-            expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq({})
+          context "Given default association value is provided" do
+            let(:blueprint) do
+              Class.new(Blueprinter::Base) do
+                fields :make
+                association :user,
+                  blueprint: Class.new(Blueprinter::Base) { identifier :id },
+                  default: {}
+              end
+            end
+
+            it "should render the default value provided for the association" do
+              expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq({})
+            end
           end
         end
       end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -79,28 +79,55 @@ shared_examples 'Base::render' do
       obj[:first_name] = nil
     end
 
-    context "Given default value is not provided" do
-      let(:result) { '{"first_name":null,"id":' + obj_id + '}' }
-      let(:blueprint) do
-        Class.new(Blueprinter::Base) do
-          field :id
-          field :first_name
+    context "Given global default field value is specified" do
+      before { Blueprinter.configure { |config| config.field_default = "N/A" } }
+      after { reset_blueprinter_config! }
+
+      context "Given default field value is not provided" do
+        let(:result) { '{"first_name":"N/A","id":' + obj_id + '}' }
+        let(:blueprint) do
+          Class.new(Blueprinter::Base) do
+            field :id
+            field :first_name
+          end
         end
+        it('global default value is rendered for nil field') { should eq(result) }
       end
-      it('returns json with specified fields') { should eq(result) }
+
+      context "Given default field value is provided" do
+        let(:result) { '{"first_name":"Unknown","id":' + obj_id + '}' }
+        let(:blueprint) do
+          Class.new(Blueprinter::Base) do
+            field :id
+            field :first_name, default: "Unknown"
+          end
+        end
+        it('field-level default value is rendered for nil field') { should eq(result) }
+      end
     end
 
-    context "Given default value is provided" do
-      let(:result) { '{"first_name":"Unknown","id":' + obj_id + '}' }
-      let(:blueprint) do
-        Class.new(Blueprinter::Base) do
-          field :id
-          field :first_name, default: "Unknown"
+    context "Given global default value is not specified" do
+      context "Given default field value is not provided" do
+        let(:result) { '{"first_name":null,"id":' + obj_id + '}' }
+        let(:blueprint) do
+          Class.new(Blueprinter::Base) do
+            field :id
+            field :first_name
+          end
         end
+        it('returns json with specified fields') { should eq(result) }
       end
-      it('returns json with specified fields') {
-        should eq(result)
-      }
+
+      context "Given default field value is provided" do
+        let(:result) { '{"first_name":"Unknown","id":' + obj_id + '}' }
+        let(:blueprint) do
+          Class.new(Blueprinter::Base) do
+            field :id
+            field :first_name, default: "Unknown"
+          end
+        end
+        it('field-level default value is rendered for nil field') { should eq(result) }
+      end
     end
   end
 

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -104,6 +104,17 @@ shared_examples 'Base::render' do
         end
         it('field-level default value is rendered for nil field') { should eq(result) }
       end
+
+      context "Given default field value is provided but is nil" do
+        let(:result) { '{"first_name":null,"id":' + obj_id + '}' }
+        let(:blueprint) do
+          Class.new(Blueprinter::Base) do
+            field :id
+            field :first_name, default: nil
+          end
+        end
+        it('field-level default value is rendered for nil field') { should eq(result) }
+      end
     end
 
     context "Given global default value is not specified" do

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -42,6 +42,16 @@ describe 'Blueprinter' do
       }
       expect(Blueprinter.configuration.unless).to be(unless_lambda)
     end
+
+    it 'should set the `field_default` option' do
+      Blueprinter.configure { |config| config.field_default = "N/A" }
+      expect(Blueprinter.configuration.field_default).to eq("N/A")
+    end
+
+    it 'should set the `association_default` option' do
+      Blueprinter.configure { |config| config.association_default = {} }
+      expect(Blueprinter.configuration.association_default).to eq({})
+    end
   end
 
   describe "::Configuration" do


### PR DESCRIPTION
Previously we only supported being able to set default values at the field/association level. This PR enables setting a global default for all fields/associations that evaluate to nil.

#### Global Config Setting
```ruby
Blueprinter.configure do |config|
  config.field_default = "N/A"
  config.association_default = {}
end
```

#### Field-level/Associaion-level Setting
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid

  view :normal do
    field :first_name, default: "N/A"
    association :company, blueprint: CompanyBlueprint, default: {}
  end
end
```

The default value specified at the field/association level will override the value specified in the global config.