### PR TITLE
[Bugfix] Serialize boolean false values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.1  - 2019/1/24
+
+* 🐛 [BUGFIX] Fix boolean `false` values getting serialized as `null`. Please see PR [#132](https://github.com/procore/blueprinter/pull/132).
+
 ## 0.12.0  - 2019/1/16
 
 * 🚀 [FEATURE] Enables the setting of global `:field_default` and `:association_default` option value in the Blueprinter Configuration that will be used as default values for fields and associations that evaluate to nil. [#128](https://github.com/procore/blueprinter/pull/128). Thanks to [@mcclayton](https://github.com/mcclayton).

--- a/lib/blueprinter/extractors/hash_extractor.rb
+++ b/lib/blueprinter/extractors/hash_extractor.rb
@@ -1,7 +1,7 @@
 module Blueprinter
   class HashExtractor < Extractor
-    def extract(field_name, object, local_options, options = {})
-      object[field_name] || object[field_name.to_s]
+    def extract(field_name, object, _local_options, _options = {})
+      object[field_name]
     end
   end
 end

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/spec/activerecord_helper.rb
+++ b/spec/activerecord_helper.rb
@@ -11,7 +11,7 @@ class Vehicle < ActiveRecord::Base
 end
 
 class User < ActiveRecord::Base
-  attr_accessor :company, :description, :position
+  attr_accessor :company, :description, :position, :active
   has_many :vehicles
 end
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20181116094242) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.boolean "active"
   end
 
   create_table "vehicles", force: :cascade do |t|

--- a/spec/factories/model_factories.rb
+++ b/spec/factories/model_factories.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     company { 'Procore' }
     birthday { Date.new(1994, 3, 4) }
     deleted_at { nil }
+    active { false }
   end
 
   factory :vehicle do

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -20,7 +20,8 @@ describe '::Base' do
       description: 'A person',
       company: 'Procore',
       birthday: Date.new(1994, 3, 4),
-      deleted_at: nil
+      deleted_at: nil,
+      active: false
     }
   end
   let(:object_with_attributes) { OpenStruct.new(obj_hash) }

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -10,6 +10,20 @@ shared_examples 'Base::render' do
     it('returns json with specified fields') { should eq(result) }
   end
 
+  context 'Given blueprint has ::field with all data types' do
+    let(:result) { '{"active":false,"birthday":"1994-03-04","deleted_at":null,"first_name":"Meg","id":' + obj_id + '}' }
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        field :id # number
+        field :first_name # string
+        field :active # boolean
+        field :birthday # date
+        field :deleted_at # null
+      end
+    end
+    it('returns json with the correct values for each data type') { should eq(result) }
+  end
+
   context 'Given blueprint has ::fields' do
     let(:result) do
       '{"id":' + obj_id + ',"description":"A person","first_name":"Meg"}'


### PR DESCRIPTION
Proposed fix for #130 

Currently blueprinter does not serialize boolean `false` values, returning `null` instead

### Change log
- Add a test to confirm the behavior is absent in the existing code, add a boolean attribute to the specs and add a specific context block for confirming the behavior of various data types
- Remove the offending OR operation, which appears unnecessary as there does not appear to be any type checking of object keys elsewhere.

