### PR TITLE
Set git config settings for releasing as bot account.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,11 @@ jobs:
           name: Installing ruby dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
       - run:
+          name: Sign in to Github as CircleCI Bot
+          command: |
+            git config --global user.email "$CIRCLECI_GIT_BOT_GIT_EMAIL"
+            git config --global user.name "$CIRCLECI_GIT_BOT_NAME"
+      - run:
           name: Auth RubyGems
           command: |
             mkdir ~/.gem


### PR DESCRIPTION
As part of this, I've configured our CircleCI to use the appropriate git ssh key and this sets the git configuration to use our CircleCI bot to tag the releases.