### PR TITLE
Remove usage of Rails specific method Hash::except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13.2  - 2019/03/14
+* 🐛 [BUGFIX] Replacing use of rails-specific method `Hash::except` so that Blueprinter continues to work in non-Rails environments. [#140](https://github.com/procore/blueprinter/pull/140). Thanks to [@checkbutton](https://github.com/checkbutton).
+
 ## 0.13.1  - 2019/03/02
 * 💅 [MAINTENANCE | ENHANCEMENT] Cleaning up the `include_associations` section. This is not a documented/supported feature and is calling `respond_to?(:klass)` on every object passed to blueprinter. [#139](https://github.com/procore/blueprinter/pull/139). Thanks to [@ritikesh](https://github.com/ritikesh).
 

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -5,7 +5,8 @@ module Blueprinter
     end
 
     def extract(association_name, object, local_options, options={})
-      value = @extractor.extract(association_name, object, local_options, options.except(:default))
+      options_without_default = options.reject { |k,_| k == :default }
+      value = @extractor.extract(association_name, object, local_options, options_without_default)
       return default_value(options) if value.nil?
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.13.1'
+  VERSION = '0.13.2'
 end


### PR DESCRIPTION
All credit for this fix goes to @checkbutton https://github.com/checkbutton
who opened up the original PR: https://github.com/procore/blueprinter/pull/136

Needing to get this in soon and couldn't merge changes into his personal branch -- so creating a new PR with those changes.

Thanks again @checkbutton 🎉 