### PR TITLE
Allow either string or procs to be used in formatting DateTime objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.14.0  - 2019/03/26
-* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strptime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#140](https://github.com/procore/blueprinter/pull/142). Thanks to [@mcclayton](https://github.com/mcclayton).
+* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strptime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#142](https://github.com/procore/blueprinter/pull/142). Thanks to [@mcclayton](https://github.com/mcclayton).
 
 ## 0.13.2  - 2019/03/14
 * 🐛 [BUGFIX] Replacing use of rails-specific method `Hash::except` so that Blueprinter continues to work in non-Rails environments. [#140](https://github.com/procore/blueprinter/pull/140). Thanks to [@checkbutton](https://github.com/checkbutton).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.0  - 2019/03/26
+* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strptime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#140](https://github.com/procore/blueprinter/pull/141). Thanks to [@mcclayton](https://github.com/mcclayton).
+
 ## 0.13.2  - 2019/03/14
 * 🐛 [BUGFIX] Replacing use of rails-specific method `Hash::except` so that Blueprinter continues to work in non-Rails environments. [#140](https://github.com/procore/blueprinter/pull/140). Thanks to [@checkbutton](https://github.com/checkbutton).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.14.0  - 2019/03/26
-* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strptime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#140](https://github.com/procore/blueprinter/pull/141). Thanks to [@mcclayton](https://github.com/mcclayton).
+* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strptime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#140](https://github.com/procore/blueprinter/pull/142). Thanks to [@mcclayton](https://github.com/mcclayton).
 
 ## 0.13.2  - 2019/03/14
 * 🐛 [BUGFIX] Replacing use of rails-specific method `Hash::except` so that Blueprinter continues to work in non-Rails environments. [#140](https://github.com/procore/blueprinter/pull/140). Thanks to [@checkbutton](https://github.com/checkbutton).

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ puts UserBlueprint.render(user, view: :normal, root: :user)
 
 Output:
 ```json
-{ 
+{
   "user": {
     "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
     "first_name": "John",
@@ -182,7 +182,7 @@ puts json
 
 Output:
 ```json
-{ 
+{
   "user": {
     "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
     "first_name": "John",
@@ -506,9 +506,12 @@ end
 The field-level setting overrides the global config setting (for the field) if both are set.
 
 ### Custom formatting for dates and times
-To define a custom format for a Date or DateTime field, include the option `datetime_format` with the associated `strptime` format.
+To define a custom format for a Date or DateTime field, include the option `datetime_format`.
+This field option can be either a string representing the associated `strptime` format,
+or a Proc which receives the original Date/DateTime object and returns the formatted value.
+When using a Proc, it is the Proc's responsibility to handle any errors in formatting.
 
-Usage:
+Usage (String Option):
 ```ruby
 class UserBlueprint < Blueprinter::Base
   identifier :name
@@ -521,6 +524,22 @@ Output:
 {
   "name": "John Doe",
   "birthday": "03/04/1994"
+}
+```
+
+Usage (Proc Option):
+```ruby
+class UserBlueprint < Blueprinter::Base
+  identifier :name
+  field :birthday, datetime_format: ->(datetime) { datetime.nil? ? datetime : datetime.strftime("%s").to_i }
+end
+```
+
+Output:
+```json
+{
+  "name": "John Doe",
+  "birthday": 762739200
 }
 ```
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -7,6 +7,8 @@ require_relative 'extractors/block_extractor'
 require_relative 'extractors/hash_extractor'
 require_relative 'extractors/public_send_extractor'
 require_relative 'field'
+require_relative 'formatter'
+require_relative 'formatters/datetime_formatter'
 require_relative 'helpers/base_helpers'
 require_relative 'view'
 require_relative 'view_collection'
@@ -70,8 +72,11 @@ module Blueprinter
     # @option options [Symbol] :name Use this to rename the method. Useful if
     #   if you want your JSON key named differently in the output than your
     #   object's field or method name.
-    # @option options [String] :datetime_format Format Date or DateTime object
-    #   with given strftime formatting
+    # @option options [String,Proc] :datetime_format Format Date or DateTime object
+    #   If the option provided is a String, the object will be formatted with given strftime
+    #   formatting.
+    #   If this option is a Proc, the object will be formatted by calling the provided Proc
+    #   on the Date/DateTime object.
     # @option options [Symbol,Proc] :if Specifies a method, proc or string to
     #   call to determine if the field should be included (e.g.
     #   `if: :include_first_name?, or if: Proc.new { |user, options| options[:current_user] == user }).
@@ -170,7 +175,7 @@ module Blueprinter
     # @option options [Symbol|String] :root Defaults to nil.
     #   Render the json/hash with a root key if provided.
     # @option options [Any] :meta Defaults to nil.
-    #   Render the json/hash with a meta attribute with provided value 
+    #   Render the json/hash with a meta attribute with provided value
     #   if both root and meta keys are provided in the options hash.
     #
     # @example Generating JSON with an extended view
@@ -195,7 +200,7 @@ module Blueprinter
     # @option options [Symbol|String] :root Defaults to nil.
     #   Render the json/hash with a root key if provided.
     # @option options [Any] :meta Defaults to nil.
-    #   Render the json/hash with a meta attribute with provided value 
+    #   Render the json/hash with a meta attribute with provided value
     #   if both root and meta keys are provided in the options hash.
     #
     # @example Generating a hash with an extended view
@@ -220,7 +225,7 @@ module Blueprinter
     # @option options [Symbol|String] :root Defaults to nil.
     #   Render the json/hash with a root key if provided.
     # @option options [Any] :meta Defaults to nil.
-    #   Render the json/hash with a meta attribute with provided value 
+    #   Render the json/hash with a meta attribute with provided value
     #   if both root and meta keys are provided in the options hash.
     #
     # @example Generating a hash with an extended view

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -4,11 +4,12 @@ module Blueprinter
       @hash_extractor = HashExtractor.new
       @public_send_extractor = PublicSendExtractor.new
       @block_extractor = BlockExtractor.new
+      @datetime_formatter = DateTimeFormatter.new
     end
 
     def extract(field_name, object, local_options, options = {})
       extraction = extractor(object, options).extract(field_name, object, local_options, options)
-      value = options.key?(:datetime_format) ? format_datetime(extraction, options[:datetime_format]) : extraction
+      value = format(extraction, options)
       value.nil? ? default_value(options) : value
     end
 
@@ -28,11 +29,12 @@ module Blueprinter
       end
     end
 
-    def format_datetime(datetime, format)
-      return nil if datetime.nil?
-      datetime.strftime(format)
-    rescue NoMethodError
-      raise BlueprinterError, 'Cannot format invalid DateTime object'
+    def format(extraction, options)
+      if options.key?(:datetime_format)
+        @datetime_formatter.format(extraction, options)
+      else
+        extraction
+      end
     end
   end
 end

--- a/lib/blueprinter/formatter.rb
+++ b/lib/blueprinter/formatter.rb
@@ -1,0 +1,12 @@
+module Blueprinter
+  # @api private
+  class Formatter
+    def format(field_name, object, local_options, options={})
+      fail NotImplementedError, "A Formatter must implement #format"
+    end
+
+    def self.format(field_name, object, local_options, options={})
+      self.new.format(field_name, object, local_options, options)
+    end
+  end
+end

--- a/lib/blueprinter/formatters/datetime_formatter.rb
+++ b/lib/blueprinter/formatters/datetime_formatter.rb
@@ -1,0 +1,23 @@
+module Blueprinter
+  class DateTimeFormatter < Formatter
+    def format(datetime, options = {})
+      return nil if datetime.nil?
+
+      format = options[:datetime_format]
+
+      if format.nil?
+        datetime
+      elsif format.is_a?(Proc)
+        format.call(datetime)
+      elsif format.is_a?(String)
+        begin
+          datetime.strftime(format)
+        rescue NoMethodError
+          raise BlueprinterError, 'Cannot format invalid DateTime object'
+        end
+      else
+        raise BlueprinterError, 'Cannot format DateTime object with invalid formatter'
+      end
+    end
+  end
+end

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.13.2'
+  VERSION = '0.14.0'
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -64,7 +64,7 @@ shared_examples 'Base::render' do
     it('returns json derived from a custom extractor') { should eq(result) }
   end
 
-  context 'Given blueprint has ::field with a :datetime_format argument' do
+  context 'Given blueprint has ::field with a string :datetime_format argument' do
     let(:result) do
       '{"id":' + obj_id + ',"birthday":"03/04/1994","deleted_at":null}'
     end
@@ -78,11 +78,45 @@ shared_examples 'Base::render' do
     it('returns json with a formatted field') { should eq(result) }
   end
 
-  context 'Given blueprint has a :datetime_format argument on an invalid ::field' do
+  context 'Given blueprint has a string :datetime_format argument on an invalid ::field' do
     let(:blueprint) do
       Class.new(Blueprinter::Base) do
         identifier :id
         field :first_name, datetime_format: "%m/%d/%Y"
+      end
+    end
+    it('raises a BlueprinterError') { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
+  end
+
+  context 'Given blueprint has ::field with a Proc :datetime_format argument' do
+    let(:result) do
+      '{"id":' + obj_id + ',"birthday":762739200,"deleted_at":null}'
+    end
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :birthday,   datetime_format: -> datetime { datetime.strftime("%s").to_i }
+        field :deleted_at, datetime_format: -> datetime { datetime.strftime("%s").to_i }
+      end
+    end
+    it('returns json with a formatted field') { should eq(result) }
+  end
+
+  context 'Given blueprint has a Proc :datetime_format argument on an invalid ::field' do
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :first_name, datetime_format: -> datetime { datetime.strftime("%s") }
+      end
+    end
+    it('raises original error from Proc') { expect{subject}.to raise_error(NoMethodError) }
+  end
+
+  context 'Given blueprint has ::field with an invalid :datetime_format argument' do
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        identifier :id
+        field :birthday, datetime_format: :invalid_symbol_format
       end
     end
     it('raises a BlueprinterError') { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
@@ -305,14 +339,14 @@ shared_examples 'Base::render' do
 
   context 'Given blueprint has :meta without :root' do
     let(:blueprint) { blueprint_with_block }
-    it('raises a BlueprinterError') { 
+    it('raises a BlueprinterError') {
       expect{blueprint.render(obj, meta: 'meta_value')}.to raise_error(Blueprinter::BlueprinterError)
     }
   end
 
   context 'Given blueprint has root as a non-supported object' do
     let(:blueprint) { blueprint_with_block }
-    it('raises a BlueprinterError') { 
+    it('raises a BlueprinterError') {
       expect{blueprint.render(obj, root: {some_key: "invalid root"})}.to raise_error(Blueprinter::BlueprinterError)
     }
   end

--- a/spec/units/datetime_formatter_spec.rb
+++ b/spec/units/datetime_formatter_spec.rb
@@ -1,0 +1,80 @@
+describe '::View' do
+  let(:formatter) { Blueprinter::DateTimeFormatter.new }
+  let(:valid_date) { Date.new(1994, 3, 4) }
+  let(:invalid_date) { "invalid_date" }
+  let(:invalid_field_options) { { datetime_format: 5 } }
+
+  describe '#format(datetime, options)' do
+    context 'Given no datetime format' do
+      it 'should return original date' do
+        expect(formatter.format(valid_date, {})).to eq(valid_date)
+      end
+    end
+
+    context 'Given string datetime format' do
+      let(:field_options) { { datetime_format: "%m/%d/%Y" } }
+
+      context 'and given valid datetime' do
+        it 'should return formatted date via strftime' do
+          expect(formatter.format(valid_date, field_options)).to eq("03/04/1994")
+        end
+      end
+
+      context 'and given invalid datetime' do
+        it 'raises a BlueprinterError' do
+          expect{formatter.format(invalid_date, field_options)}.to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
+
+      context 'and given invalid format' do
+        it 'raises a BlueprinterError' do
+          expect{formatter.format(valid_date, invalid_field_options)}.to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
+    end
+
+    context 'Given Proc datetime format' do
+      let(:field_options) { { datetime_format: -> datetime { datetime.year.to_s } } }
+
+      context 'and given valid datetime' do
+        it 'should return formatted date via proc' do
+          expect(formatter.format(valid_date, field_options)).to eq("1994")
+        end
+      end
+
+      context 'and given invalid datetime' do
+        it 'raises original error from Proc' do
+          expect{formatter.format(invalid_date, field_options)}.to raise_error(NoMethodError)
+        end
+      end
+
+      context 'and given invalid format' do
+        it 'raises a BlueprinterError' do
+          expect{formatter.format(valid_date, invalid_field_options)}.to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
+    end
+
+    context 'Given invalid datetime format' do
+      let(:field_options) { { datetime_format: 5 } }
+
+      context 'and given valid datetime' do
+        it 'raises a BlueprinterError' do
+          expect{formatter.format(valid_date, field_options)}.to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
+
+      context 'and given invalid datetime' do
+        it 'raises a BlueprinterError' do
+          expect{formatter.format(invalid_date, field_options)}.to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
+
+      context 'and given invalid format' do
+        it 'raises a BlueprinterError' do
+          expect{formatter.format(invalid_date, invalid_field_options)}.to raise_error(Blueprinter::BlueprinterError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This aims to address https://github.com/procore/blueprinter/issues/120

Previously, we had a field level option `datetime_format` which takes in a string representing the strptime format to format the Date/DateTime object. This PR enables `datetime_format` to be either a String *or* a Proc. This enables more flexibility, especially for those who want to have something like integer UNIX timestamps.


### Usage (String Option):
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :name
  field :birthday, datetime_format: "%m/%d/%Y"
end
```
Output:
```json
{
  "name": "John Doe",
  "birthday": "03/04/1994"
}
```

### Usage (Proc Option):
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :name
  field :birthday, datetime_format: ->(datetime) { datetime.nil? ? datetime : datetime.strftime("%s").to_i }
end
```

Output:
```json
{
  "name": "John Doe",
  "birthday": 762739200
}
```