### PR TITLE
Cleanup README and make Usage Instructions Collapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.15.0  - 2019/04/1
-* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strptime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#145](https://github.com/procore/blueprinter/pull/145). Thanks to [@mcclayton](https://github.com/mcclayton).
+* 🚀 [FEATURE] Add ability to pass in `datetime_format` field option as either a string representing the strftime format, or a Proc which takes in the Date or DateTime object and returns the formatted date. [#145](https://github.com/procore/blueprinter/pull/145). Thanks to [@mcclayton](https://github.com/mcclayton).
 
 ## 0.14.0  - 2019/04/01
 * 🚀 [FEATURE] Added a global `datetime_format` option. [#135](https://github.com/procore/blueprinter/pull/143). Thanks to [@ritikesh](https://github.com/ritikesh).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 
 ## Usage
 <details>
-<summary>Basic</summary>
+<summary>_Basic_</summary>
 
 If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.
 
@@ -45,8 +45,10 @@ And the output would look like:
 ```
 </details>
 
+---
+
 <details>
-<summary>Collections</summary>
+<summary>_Collections_</summary>
 
 You can also pass a collection object or an array to the render method.
 
@@ -74,8 +76,10 @@ This will result in JSON that looks something like this:
 ```
 </details>
 
+---
+
 <details>
-<summary>Renaming</summary>
+<summary>_Renaming_</summary>
 You can rename the resulting JSON keys in both fields and associations by using the `name` option.
 
 ```ruby
@@ -99,8 +103,10 @@ This will result in JSON that looks something like this:
 ```
 </details>
 
+---
+
 <details>
-<summary>Views</summary>
+<summary>_Views_</summary>
 
 You may define different outputs by utilizing views:
 ```ruby
@@ -137,8 +143,10 @@ Output:
 ```
 </details>
 
+---
+
 <details>
-<summary>Root</summary>
+<summary>_Root_</summary>
 
 You can also optionally pass in a root key to wrap your resulting json in:
 ```ruby
@@ -170,8 +178,10 @@ Output:
 ```
 </details>
 
+---
+
 <details>
-<summary>Meta Attributes</summary>
+<summary>_Meta Attributes_</summary>
 
 You can additionally add meta-data to the json as well:
 ```ruby
@@ -214,8 +224,10 @@ Output:
 _NOTE:_ For meta attributes, a [root](#root) is mandatory.
 </details>
 
+---
+
 <details>
-<summary>Exclude Fields</summary>
+<summary>_Exclude Fields_</summary>
 
 You can specifically choose to exclude certain fields for specific views
 ```ruby
@@ -251,8 +263,10 @@ Output:
 ```
 </details>
 
+---
+
 <details>
-<summary>Associations</summary>
+<summary>_Associations_</summary>
 
 You may include associated objects. Say for example, a user has projects:
 ```ruby
@@ -298,8 +312,10 @@ Output:
 ```
 </details>
 
+---
+
 <details>
-<summary>Default Association/Field Option</summary>
+<summary>_Default Association/Field Option_</summary>
 
 By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
 
@@ -324,8 +340,10 @@ end
 ```
 </details>
 
+---
+
 <details>
-<summary>Supporting Dynamic Blueprints for Associations</summary>
+<summary>_Supporting Dynamic Blueprints for Associations_</summary>
 
 When defining an association, we can dynamically evaluate the blueprint. This comes in handy when adding polymorphic associations, by allowing reuse of existing blueprints.
 ```ruby
@@ -353,8 +371,10 @@ end
 _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `has_many` is not supported because of the very nature of polymorphic associations.
 </details>
 
+---
+
 <details>
-<summary>Defining a field directly in the Blueprint</summary>
+<summary>_Defining a field directly in the Blueprint_</summary>
 
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
 
@@ -383,8 +403,10 @@ Output:
 ```
 </details>
 
+---
+
 <details>
-<summary>Defining an identifier directly in the Blueprint</summary>
+<summary>_Defining an identifier directly in the Blueprint_</summary>
 
 You can also pass a block to an identifier:
 
@@ -411,8 +433,10 @@ Output:
 ```
 </details>
 
+---
+
 <details>
-<summary>Defining an association directly in the Blueprint</summary>
+<summary>_Defining an association directly in the Blueprint_</summary>
 
 You can also pass a block to an association:
 
@@ -451,9 +475,10 @@ Output:
 ```
 </details>
 
+---
 
 <details>
-<summary>Passing additional properties to `render`</summary>
+<summary>_Passing additional properties to `render`_</summary>
 
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
 
@@ -482,6 +507,7 @@ Output:
 ```
 </details>
 
+---
 
 <details>
 <summary>`render_as_hash`</summary>
@@ -504,6 +530,7 @@ Output:
 ```
 </details>
 
+---
 
 <details>
 <summary>`render_as_json`</summary>
@@ -526,9 +553,10 @@ Output:
 ```
 </details>
 
+---
 
 <details>
-<summary>Conditional Fields</summary>
+<summary>_Conditional Fields_</summary>
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
 
@@ -552,9 +580,10 @@ end
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
 </details>
 
+---
 
 <details>
-<summary>Custom Formatting for Dates and Times</summary>
+<summary>_Custom Formatting for Dates and Times_</summary>
 
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
 This global or field-level option can be either a string representing the associated `strptime` format,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 ## Usage
 <details>
 <summary>Basic</summary>
-
+---
 If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.
 
 You may define a simple blueprint like so:
@@ -43,12 +43,13 @@ And the output would look like:
   "last_name": "Doe"
 }
 ```
+---
 </details>
 
 
 <details>
-<summary>_Collections_</summary>
-
+<summary>Collections</summary>
+---
 You can also pass a collection object or an array to the render method.
 
 ```ruby
@@ -73,11 +74,13 @@ This will result in JSON that looks something like this:
   }
 ]
 ```
+---
 </details>
 
 
 <details>
 <summary>Renaming</summary>
+---
 You can rename the resulting JSON keys in both fields and associations by using the `name` option.
 
 ```ruby
@@ -99,12 +102,13 @@ This will result in JSON that looks something like this:
   "projects": []
 }
 ```
+---
 </details>
 
 
 <details>
 <summary>Views</summary>
-
+---
 You may define different outputs by utilizing views:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -138,12 +142,13 @@ Output:
   "login": "john.doe@some.fake.email.domain"
 }
 ```
+---
 </details>
 
 
 <details>
 <summary>Root</summary>
-
+---
 You can also optionally pass in a root key to wrap your resulting json in:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -172,12 +177,13 @@ Output:
   }
 }
 ```
+---
 </details>
 
 
 <details>
 <summary>Meta Attributes</summary>
-
+---
 You can additionally add meta-data to the json as well:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -217,12 +223,13 @@ Output:
 }
 ```
 _NOTE:_ For meta attributes, a [root](#root) is mandatory.
+---
 </details>
 
 
 <details>
 <summary>Exclude Fields</summary>
-
+---
 You can specifically choose to exclude certain fields for specific views
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -255,12 +262,13 @@ Output:
   "login": "john.doe@some.fake.email.domain"
 }
 ```
+---
 </details>
 
 
 <details>
 <summary>Associations</summary>
-
+---
 You may include associated objects. Say for example, a user has projects:
 ```ruby
 class ProjectBlueprint < Blueprinter::Base
@@ -303,12 +311,13 @@ Output:
   ]
 }
 ```
+---
 </details>
 
 
 <details>
 <summary>Default Association/Field Option</summary>
-
+---
 By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
 
 #### Global Config Setting
@@ -330,12 +339,13 @@ class UserBlueprint < Blueprinter::Base
   end
 end
 ```
+---
 </details>
 
 
 <details>
-<summary>Supporting Dynamic Blueprints for Associations</summary>
-
+<summary>Supporting Dynamic Blueprints For Associations</summary>
+---
 When defining an association, we can dynamically evaluate the blueprint. This comes in handy when adding polymorphic associations, by allowing reuse of existing blueprints.
 ```ruby
 class Task < ActiveRecord::Base
@@ -360,12 +370,13 @@ class TaskBlueprint < Blueprinter::Base
 end
 ```
 _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `has_many` is not supported because of the very nature of polymorphic associations.
+---
 </details>
 
 
 <details>
-<summary>Defining a field directly in the Blueprint</summary>
-
+<summary>Defining A Field Directly In The Blueprint</summary>
+---
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
 
 ```ruby
@@ -391,12 +402,13 @@ Output:
   "full_name": "Mr John Doe"
 }
 ```
+---
 </details>
 
 
 <details>
-<summary>Defining an identifier directly in the Blueprint</summary>
-
+<summary>Defining An Identifier Directly In The Blueprint</summary>
+---
 You can also pass a block to an identifier:
 
 ```ruby
@@ -420,12 +432,13 @@ Output:
   "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
 }
 ```
+---
 </details>
 
 
 <details>
-<summary>Defining an association directly in the Blueprint</summary>
-
+<summary>Defining An Association Directly In The Blueprint</summary>
+---
 You can also pass a block to an association:
 
 ```ruby
@@ -461,12 +474,13 @@ Output:
   ]
 }
 ```
+---
 </details>
 
 
 <details>
-<summary>Passing additional properties to `render`</summary>
-
+<summary>Passing Additional Properties To #render</summary>
+---
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
 
 ```ruby
@@ -492,56 +506,13 @@ Output:
   "company_name": "My Company LLC"
 }
 ```
-</details>
-
-
-<details>
-<summary>`render_as_hash`</summary>
-
-Same as `render`, returns a Ruby Hash.
-
-Usage:
-
-```ruby
-puts UserBlueprint.render_as_hash(user, company: company)
-```
-
-Output:
-
-```ruby
-{
-  uuid: "733f0758-8f21-4719-875f-262c3ec743af",
-  company_name: "My Company LLC"
-}
-```
-</details>
-
-
-<details>
-<summary>`render_as_json`</summary>
-
-Same as `render`, returns a Ruby Hash JSONified. This will call JSONify all keys and values.
-
-Usage:
-
-```ruby
-puts UserBlueprint.render_as_json(user, company: company)
-```
-
-Output:
-
-```ruby
-{
-  "uuid" => "733f0758-8f21-4719-875f-262c3ec743af",
-  "company_name" => "My Company LLC"
-}
-```
+---
 </details>
 
 
 <details>
 <summary>Conditional Fields</summary>
-
+---
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
 
 #### Global Config Setting
@@ -562,12 +533,13 @@ end
 ```
 
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
+---
 </details>
 
 
 <details>
 <summary>Custom Formatting for Dates and Times</summary>
-
+---
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
 This global or field-level option can be either a string representing the associated `strptime` format,
 or a Proc which receives the original Date/DateTime object and returns the formatted value.
@@ -617,12 +589,13 @@ Output:
 ```
 
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
+---
 </details>
 
 
 <details>
-<summary>Sorting</summary>
-
+<summary>Sorting Fields</summary>
+---
 By default the response sorts the keys by name. If you want the fields to be sorted in the order of definition, use the below configuration option.
 
 Usage:
@@ -649,6 +622,53 @@ Output:
   "birthday": "03/04/1994"
 }
 ```
+---
+</details>
+
+
+<details>
+<summary>#render_as_hash</summary>
+---
+Same as `render`, returns a Ruby Hash.
+
+Usage:
+
+```ruby
+puts UserBlueprint.render_as_hash(user, company: company)
+```
+
+Output:
+
+```ruby
+{
+  uuid: "733f0758-8f21-4719-875f-262c3ec743af",
+  company_name: "My Company LLC"
+}
+```
+---
+</details>
+
+
+<details>
+<summary>#render_as_json</summary>
+---
+Same as `render`, returns a Ruby Hash JSONified. This will call JSONify all keys and values.
+
+Usage:
+
+```ruby
+puts UserBlueprint.render_as_json(user, company: company)
+```
+
+Output:
+
+```ruby
+{
+  "uuid" => "733f0758-8f21-4719-875f-262c3ec743af",
+  "company_name" => "My Company LLC"
+}
+```
+---
 </details>
 
 
@@ -705,14 +725,6 @@ end
 
 _NOTE:_ You should be doing this only if you aren't using `yajl-ruby` through the JSON API by requiring `yajl/json_gem`. More details [here](https://github.com/brianmario/yajl-ruby#json-gem-compatibility-api). In this case, `JSON.generate` is patched to use `Yajl::Encoder.encode` internally.
 
-## How to Document
-
-We use [Yard](https://yardoc.org/) for documentation. Here are the following
-documentation rules:
-
-- Document all public methods we expect to be utilized by the end developers.
-- Methods that are not set to private due to ruby visibility rule limitations should be marked with `@api private`.
-
 ## Contributing
 Feel free to browse the issues, converse, and make pull requests. If you need help, first please see if there is already an issue for your problem. Otherwise, go ahead and make a new issue.
 
@@ -721,6 +733,14 @@ You can run tests with `bundle exec rake`.
 
 ### Maintain The Docs
 We use Yard for documentation. Here are the following documentation rules:
+
+- Document all public methods we expect to be utilized by the end developers.
+- Methods that are not set to private due to ruby visibility rule limitations should be marked with `@api private`.
+
+## How to Document
+
+We use [Yard](https://yardoc.org/) for documentation. Here are the following
+documentation rules:
 
 - Document all public methods we expect to be utilized by the end developers.
 - Methods that are not set to private due to ruby visibility rule limitations should be marked with `@api private`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It heavily relies on the idea of `views` which, similar to Rails views, are ways
 Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 
 ## Usage
-<details>
+<details open>
 <summary>Basic</summary>
 
 ---

--- a/README.md
+++ b/README.md
@@ -588,14 +588,14 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 ---
 
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
-This global or field-level option can be either a string representing the associated `strptime` format,
+This global or field-level option can be either a string representing the associated `strftime` format,
 or a Proc which receives the original Date/DateTime object and returns the formatted value.
 When using a Proc, it is the Proc's responsibility to handle any errors in formatting.
 
 
 #### Global Config Setting
 If a global datetime_format is set (either as a string format or a Proc), this option will be
-invoked and used to format all fields that respond to `strptime`.
+invoked and used to format all fields that respond to `strftime`.
 ```ruby
 Blueprinter.configure do |config|
   config.datetime_format = ->(datetime) { datetime.nil? ? datetime : datetime.strftime("%s").to_i }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 <details>
 <summary>Basic</summary>
 ---
+
 If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.
 
 You may define a simple blueprint like so:
@@ -50,6 +51,7 @@ And the output would look like:
 <details>
 <summary>Collections</summary>
 ---
+
 You can also pass a collection object or an array to the render method.
 
 ```ruby
@@ -81,6 +83,7 @@ This will result in JSON that looks something like this:
 <details>
 <summary>Renaming</summary>
 ---
+
 You can rename the resulting JSON keys in both fields and associations by using the `name` option.
 
 ```ruby
@@ -109,6 +112,7 @@ This will result in JSON that looks something like this:
 <details>
 <summary>Views</summary>
 ---
+
 You may define different outputs by utilizing views:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -149,6 +153,7 @@ Output:
 <details>
 <summary>Root</summary>
 ---
+
 You can also optionally pass in a root key to wrap your resulting json in:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -184,6 +189,7 @@ Output:
 <details>
 <summary>Meta Attributes</summary>
 ---
+
 You can additionally add meta-data to the json as well:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -230,6 +236,7 @@ _NOTE:_ For meta attributes, a [root](#root) is mandatory.
 <details>
 <summary>Exclude Fields</summary>
 ---
+
 You can specifically choose to exclude certain fields for specific views
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -269,6 +276,7 @@ Output:
 <details>
 <summary>Associations</summary>
 ---
+
 You may include associated objects. Say for example, a user has projects:
 ```ruby
 class ProjectBlueprint < Blueprinter::Base
@@ -318,6 +326,7 @@ Output:
 <details>
 <summary>Default Association/Field Option</summary>
 ---
+
 By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
 
 #### Global Config Setting
@@ -346,6 +355,7 @@ end
 <details>
 <summary>Supporting Dynamic Blueprints For Associations</summary>
 ---
+
 When defining an association, we can dynamically evaluate the blueprint. This comes in handy when adding polymorphic associations, by allowing reuse of existing blueprints.
 ```ruby
 class Task < ActiveRecord::Base
@@ -377,6 +387,7 @@ _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `
 <details>
 <summary>Defining A Field Directly In The Blueprint</summary>
 ---
+
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
 
 ```ruby
@@ -409,6 +420,7 @@ Output:
 <details>
 <summary>Defining An Identifier Directly In The Blueprint</summary>
 ---
+
 You can also pass a block to an identifier:
 
 ```ruby
@@ -439,6 +451,7 @@ Output:
 <details>
 <summary>Defining An Association Directly In The Blueprint</summary>
 ---
+
 You can also pass a block to an association:
 
 ```ruby
@@ -481,6 +494,7 @@ Output:
 <details>
 <summary>Passing Additional Properties To #render</summary>
 ---
+
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
 
 ```ruby
@@ -513,6 +527,7 @@ Output:
 <details>
 <summary>Conditional Fields</summary>
 ---
+
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
 
 #### Global Config Setting
@@ -540,6 +555,7 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 <details>
 <summary>Custom Formatting for Dates and Times</summary>
 ---
+
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
 This global or field-level option can be either a string representing the associated `strptime` format,
 or a Proc which receives the original Date/DateTime object and returns the formatted value.
@@ -596,6 +612,7 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 <details>
 <summary>Sorting Fields</summary>
 ---
+
 By default the response sorts the keys by name. If you want the fields to be sorted in the order of definition, use the below configuration option.
 
 Usage:
@@ -627,8 +644,9 @@ Output:
 
 
 <details>
-<summary>#render_as_hash</summary>
+<summary>render_as_hash</summary>
 ---
+
 Same as `render`, returns a Ruby Hash.
 
 Usage:
@@ -650,8 +668,9 @@ Output:
 
 
 <details>
-<summary>#render_as_json</summary>
+<summary>render_as_json</summary>
 ---
+
 Same as `render`, returns a Ruby Hash JSONified. This will call JSONify all keys and values.
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ It heavily relies on the idea of `views` which, similar to Rails views, are ways
 Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 
 ## Usage
-### Basic
+<details>
+<summary>Basic</summary>
+
 If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.
 
 You may define a simple blueprint like so:
@@ -41,8 +43,10 @@ And the output would look like:
   "last_name": "Doe"
 }
 ```
+</details>
 
-### Collections
+<details>
+<summary>Collections</summary>
 
 You can also pass a collection object or an array to the render method.
 
@@ -68,9 +72,10 @@ This will result in JSON that looks something like this:
   }
 ]
 ```
+</details>
 
-### Renaming
-
+<details>
+<summary>Renaming</summary>
 You can rename the resulting JSON keys in both fields and associations by using the `name` option.
 
 ```ruby
@@ -92,8 +97,11 @@ This will result in JSON that looks something like this:
   "projects": []
 }
 ```
+</details>
 
-### Views
+<details>
+<summary>Views</summary>
+
 You may define different outputs by utilizing views:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -127,8 +135,11 @@ Output:
   "login": "john.doe@some.fake.email.domain"
 }
 ```
+</details>
 
-### Root
+<details>
+<summary>Root</summary>
+
 You can also optionally pass in a root key to wrap your resulting json in:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -157,8 +168,11 @@ Output:
   }
 }
 ```
+</details>
 
-### Meta attributes
+<details>
+<summary>Meta Attributes</summary>
+
 You can additionally add meta-data to the json as well:
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -198,8 +212,11 @@ Output:
 }
 ```
 _NOTE:_ For meta attributes, a [root](#root) is mandatory.
+</details>
 
-### Exclude fields
+<details>
+<summary>Exclude Fields</summary>
+
 You can specifically choose to exclude certain fields for specific views
 ```ruby
 class UserBlueprint < Blueprinter::Base
@@ -232,8 +249,11 @@ Output:
   "login": "john.doe@some.fake.email.domain"
 }
 ```
+</details>
 
-### Associations
+<details>
+<summary>Associations</summary>
+
 You may include associated objects. Say for example, a user has projects:
 ```ruby
 class ProjectBlueprint < Blueprinter::Base
@@ -276,8 +296,11 @@ Output:
   ]
 }
 ```
+</details>
 
-### Default Association/Field Option
+<details>
+<summary>Default Association/Field Option</summary>
+
 By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
 
 #### Global Config Setting
@@ -299,8 +322,11 @@ class UserBlueprint < Blueprinter::Base
   end
 end
 ```
+</details>
 
-### Supporting Dynamic Blueprints for associations
+<details>
+<summary>Supporting Dynamic Blueprints for Associations</summary>
+
 When defining an association, we can dynamically evaluate the blueprint. This comes in handy when adding polymorphic associations, by allowing reuse of existing blueprints.
 ```ruby
 class Task < ActiveRecord::Base
@@ -325,8 +351,10 @@ class TaskBlueprint < Blueprinter::Base
 end
 ```
 _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `has_many` is not supported because of the very nature of polymorphic associations.
+</details>
 
-### Defining a field directly in the Blueprint
+<details>
+<summary>Defining a field directly in the Blueprint</summary>
 
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
 
@@ -353,8 +381,10 @@ Output:
   "full_name": "Mr John Doe"
 }
 ```
+</details>
 
-#### Defining an identifier directly in the Blueprint
+<details>
+<summary>Defining an identifier directly in the Blueprint</summary>
 
 You can also pass a block to an identifier:
 
@@ -379,8 +409,10 @@ Output:
   "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
 }
 ```
+</details>
 
-#### Defining an association directly in the Blueprint
+<details>
+<summary>Defining an association directly in the Blueprint</summary>
 
 You can also pass a block to an association:
 
@@ -417,8 +449,11 @@ Output:
   ]
 }
 ```
+</details>
 
-### Passing additional properties to `render`
+
+<details>
+<summary>Passing additional properties to `render`</summary>
 
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
 
@@ -445,8 +480,12 @@ Output:
   "company_name": "My Company LLC"
 }
 ```
+</details>
 
-### render_as_hash
+
+<details>
+<summary>`render_as_hash`</summary>
+
 Same as `render`, returns a Ruby Hash.
 
 Usage:
@@ -463,8 +502,12 @@ Output:
   company_name: "My Company LLC"
 }
 ```
+</details>
 
-### render_as_json
+
+<details>
+<summary>`render_as_json`</summary>
+
 Same as `render`, returns a Ruby Hash JSONified. This will call JSONify all keys and values.
 
 Usage:
@@ -481,8 +524,11 @@ Output:
   "company_name" => "My Company LLC"
 }
 ```
+</details>
 
-### Conditional fields
+
+<details>
+<summary>Conditional Fields</summary>
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
 
@@ -504,8 +550,12 @@ end
 ```
 
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
+</details>
 
-### Custom formatting for dates and times
+
+<details>
+<summary>Custom Formatting for Dates and Times</summary>
+
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
 This global or field-level option can be either a string representing the associated `strptime` format,
 or a Proc which receives the original Date/DateTime object and returns the formatted value.
@@ -555,6 +605,7 @@ Output:
 ```
 
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
+</details>
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 ## Usage
 <details>
 <summary>Basic</summary>
+
 ---
 
 If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.
@@ -50,6 +51,7 @@ And the output would look like:
 
 <details>
 <summary>Collections</summary>
+
 ---
 
 You can also pass a collection object or an array to the render method.
@@ -82,6 +84,7 @@ This will result in JSON that looks something like this:
 
 <details>
 <summary>Renaming</summary>
+
 ---
 
 You can rename the resulting JSON keys in both fields and associations by using the `name` option.
@@ -111,6 +114,7 @@ This will result in JSON that looks something like this:
 
 <details>
 <summary>Views</summary>
+
 ---
 
 You may define different outputs by utilizing views:
@@ -152,6 +156,7 @@ Output:
 
 <details>
 <summary>Root</summary>
+
 ---
 
 You can also optionally pass in a root key to wrap your resulting json in:
@@ -188,6 +193,7 @@ Output:
 
 <details>
 <summary>Meta Attributes</summary>
+
 ---
 
 You can additionally add meta-data to the json as well:
@@ -235,6 +241,7 @@ _NOTE:_ For meta attributes, a [root](#root) is mandatory.
 
 <details>
 <summary>Exclude Fields</summary>
+
 ---
 
 You can specifically choose to exclude certain fields for specific views
@@ -275,6 +282,7 @@ Output:
 
 <details>
 <summary>Associations</summary>
+
 ---
 
 You may include associated objects. Say for example, a user has projects:
@@ -325,6 +333,7 @@ Output:
 
 <details>
 <summary>Default Association/Field Option</summary>
+
 ---
 
 By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
@@ -354,6 +363,7 @@ end
 
 <details>
 <summary>Supporting Dynamic Blueprints For Associations</summary>
+
 ---
 
 When defining an association, we can dynamically evaluate the blueprint. This comes in handy when adding polymorphic associations, by allowing reuse of existing blueprints.
@@ -386,6 +396,7 @@ _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `
 
 <details>
 <summary>Defining A Field Directly In The Blueprint</summary>
+
 ---
 
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
@@ -419,6 +430,7 @@ Output:
 
 <details>
 <summary>Defining An Identifier Directly In The Blueprint</summary>
+
 ---
 
 You can also pass a block to an identifier:
@@ -450,6 +462,7 @@ Output:
 
 <details>
 <summary>Defining An Association Directly In The Blueprint</summary>
+
 ---
 
 You can also pass a block to an association:
@@ -493,6 +506,7 @@ Output:
 
 <details>
 <summary>Passing Additional Properties To #render</summary>
+
 ---
 
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
@@ -526,6 +540,7 @@ Output:
 
 <details>
 <summary>Conditional Fields</summary>
+
 ---
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
@@ -554,6 +569,7 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 
 <details>
 <summary>Custom Formatting for Dates and Times</summary>
+
 ---
 
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
@@ -611,6 +627,7 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 
 <details>
 <summary>Sorting Fields</summary>
+
 ---
 
 By default the response sorts the keys by name. If you want the fields to be sorted in the order of definition, use the below configuration option.
@@ -645,6 +662,7 @@ Output:
 
 <details>
 <summary>render_as_hash</summary>
+
 ---
 
 Same as `render`, returns a Ruby Hash.
@@ -669,6 +687,7 @@ Output:
 
 <details>
 <summary>render_as_json</summary>
+
 ---
 
 Same as `render`, returns a Ruby Hash JSONified. This will call JSONify all keys and values.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ And the output would look like:
   "last_name": "Doe"
 }
 ```
+
 ---
 </details>
 
@@ -78,6 +79,7 @@ This will result in JSON that looks something like this:
   }
 ]
 ```
+
 ---
 </details>
 
@@ -108,6 +110,7 @@ This will result in JSON that looks something like this:
   "projects": []
 }
 ```
+
 ---
 </details>
 
@@ -150,6 +153,7 @@ Output:
   "login": "john.doe@some.fake.email.domain"
 }
 ```
+
 ---
 </details>
 
@@ -187,6 +191,7 @@ Output:
   }
 }
 ```
+
 ---
 </details>
 
@@ -235,6 +240,7 @@ Output:
 }
 ```
 _NOTE:_ For meta attributes, a [root](#root) is mandatory.
+
 ---
 </details>
 
@@ -276,6 +282,7 @@ Output:
   "login": "john.doe@some.fake.email.domain"
 }
 ```
+
 ---
 </details>
 
@@ -327,6 +334,7 @@ Output:
   ]
 }
 ```
+
 ---
 </details>
 
@@ -357,6 +365,7 @@ class UserBlueprint < Blueprinter::Base
   end
 end
 ```
+
 ---
 </details>
 
@@ -390,6 +399,7 @@ class TaskBlueprint < Blueprinter::Base
 end
 ```
 _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `has_many` is not supported because of the very nature of polymorphic associations.
+
 ---
 </details>
 
@@ -424,6 +434,7 @@ Output:
   "full_name": "Mr John Doe"
 }
 ```
+
 ---
 </details>
 
@@ -456,6 +467,7 @@ Output:
   "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
 }
 ```
+
 ---
 </details>
 
@@ -500,6 +512,7 @@ Output:
   ]
 }
 ```
+
 ---
 </details>
 
@@ -534,6 +547,7 @@ Output:
   "company_name": "My Company LLC"
 }
 ```
+
 ---
 </details>
 
@@ -563,6 +577,7 @@ end
 ```
 
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
+
 ---
 </details>
 
@@ -621,6 +636,7 @@ Output:
 ```
 
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
+
 ---
 </details>
 
@@ -656,6 +672,7 @@ Output:
   "birthday": "03/04/1994"
 }
 ```
+
 ---
 </details>
 
@@ -681,6 +698,7 @@ Output:
   company_name: "My Company LLC"
 }
 ```
+
 ---
 </details>
 
@@ -706,6 +724,7 @@ Output:
   "company_name" => "My Company LLC"
 }
 ```
+
 ---
 </details>
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docs can be found [here](http://www.rubydoc.info/gems/blueprinter).
 
 ## Usage
 <details>
-<summary>_Basic_</summary>
+<summary>Basic</summary>
 
 If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.
 
@@ -45,7 +45,6 @@ And the output would look like:
 ```
 </details>
 
----
 
 <details>
 <summary>_Collections_</summary>
@@ -76,10 +75,9 @@ This will result in JSON that looks something like this:
 ```
 </details>
 
----
 
 <details>
-<summary>_Renaming_</summary>
+<summary>Renaming</summary>
 You can rename the resulting JSON keys in both fields and associations by using the `name` option.
 
 ```ruby
@@ -103,10 +101,9 @@ This will result in JSON that looks something like this:
 ```
 </details>
 
----
 
 <details>
-<summary>_Views_</summary>
+<summary>Views</summary>
 
 You may define different outputs by utilizing views:
 ```ruby
@@ -143,10 +140,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Root_</summary>
+<summary>Root</summary>
 
 You can also optionally pass in a root key to wrap your resulting json in:
 ```ruby
@@ -178,10 +174,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Meta Attributes_</summary>
+<summary>Meta Attributes</summary>
 
 You can additionally add meta-data to the json as well:
 ```ruby
@@ -224,10 +219,9 @@ Output:
 _NOTE:_ For meta attributes, a [root](#root) is mandatory.
 </details>
 
----
 
 <details>
-<summary>_Exclude Fields_</summary>
+<summary>Exclude Fields</summary>
 
 You can specifically choose to exclude certain fields for specific views
 ```ruby
@@ -263,10 +257,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Associations_</summary>
+<summary>Associations</summary>
 
 You may include associated objects. Say for example, a user has projects:
 ```ruby
@@ -312,10 +305,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Default Association/Field Option_</summary>
+<summary>Default Association/Field Option</summary>
 
 By default, an association or field that evaluates to `nil` is serialized as `nil`. A default serialized value can be specified as an option on the association or field for cases when the association/field could potentially evaluate to `nil`. You can also specify a global `field_default` or `association_default` in the Blueprinter config which will be used for all fields/associations that evaluate to nil.
 
@@ -340,10 +332,9 @@ end
 ```
 </details>
 
----
 
 <details>
-<summary>_Supporting Dynamic Blueprints for Associations_</summary>
+<summary>Supporting Dynamic Blueprints for Associations</summary>
 
 When defining an association, we can dynamically evaluate the blueprint. This comes in handy when adding polymorphic associations, by allowing reuse of existing blueprints.
 ```ruby
@@ -371,10 +362,9 @@ end
 _NOTE:_ `taskable.blueprint` should return a valid Blueprint class. Currently, `has_many` is not supported because of the very nature of polymorphic associations.
 </details>
 
----
 
 <details>
-<summary>_Defining a field directly in the Blueprint_</summary>
+<summary>Defining a field directly in the Blueprint</summary>
 
 You can define a field directly in the Blueprint by passing it a block. This is especially useful if the object does not already have such an attribute or method defined, and you want to define it specifically for use with the Blueprint. This is done by passing `field` a block. The block also yields the object and any options that were passed from `render`. For example:
 
@@ -403,10 +393,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Defining an identifier directly in the Blueprint_</summary>
+<summary>Defining an identifier directly in the Blueprint</summary>
 
 You can also pass a block to an identifier:
 
@@ -433,10 +422,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Defining an association directly in the Blueprint_</summary>
+<summary>Defining an association directly in the Blueprint</summary>
 
 You can also pass a block to an association:
 
@@ -475,10 +463,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Passing additional properties to `render`_</summary>
+<summary>Passing additional properties to `render`</summary>
 
 `render` takes an options hash which you can pass additional properties, allowing you to utilize those additional properties in the `field` block. For example:
 
@@ -507,7 +494,6 @@ Output:
 ```
 </details>
 
----
 
 <details>
 <summary>`render_as_hash`</summary>
@@ -530,7 +516,6 @@ Output:
 ```
 </details>
 
----
 
 <details>
 <summary>`render_as_json`</summary>
@@ -553,10 +538,9 @@ Output:
 ```
 </details>
 
----
 
 <details>
-<summary>_Conditional Fields_</summary>
+<summary>Conditional Fields</summary>
 
 Both the `field` and the global Blueprinter Configuration supports `:if` and `:unless` options that can be used to serialize fields conditionally.
 
@@ -580,10 +564,9 @@ end
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
 </details>
 
----
 
 <details>
-<summary>_Custom Formatting for Dates and Times_</summary>
+<summary>Custom Formatting for Dates and Times</summary>
 
 To define a custom format for a Date or DateTime field, include the option `datetime_format`.
 This global or field-level option can be either a string representing the associated `strptime` format,
@@ -636,26 +619,10 @@ Output:
 _NOTE:_ The field-level setting overrides the global config setting (for the field) if both are set.
 </details>
 
-## Installation
-Add this line to your application's Gemfile:
 
-```ruby
-gem 'blueprinter'
-```
+<details>
+<summary>Sorting</summary>
 
-And then execute:
-```bash
-$ bundle
-```
-
-Or install it yourself as:
-```bash
-$ gem install blueprinter
-```
-
-You should also have `require 'json'` already in your project if you are not using Rails or if you are not using Oj.
-
-## Sorting
 By default the response sorts the keys by name. If you want the fields to be sorted in the order of definition, use the below configuration option.
 
 Usage:
@@ -682,6 +649,27 @@ Output:
   "birthday": "03/04/1994"
 }
 ```
+</details>
+
+
+## Installation
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'blueprinter'
+```
+
+And then execute:
+```bash
+$ bundle
+```
+
+Or install it yourself as:
+```bash
+$ gem install blueprinter
+```
+
+You should also have `require 'json'` already in your project if you are not using Rails or if you are not using Oj.
 
 ## OJ
 


### PR DESCRIPTION
The README is getting quite large, this makes things a lot cleaner by making the Usage instruction sections all collapsible and some other general reorganization. This keeps the basic usage sections open by default (still collapsible) though to provide quick usage instructions at a glance.

i.e.
## Usage
<details open>
<summary>Basic</summary>

---

If you have an object you would like serialized, simply create a blueprint. Say, for example, you have a User record with the following attributes `[:uuid, :email, :first_name, :last_name, :password, :address]`.

You may define a simple blueprint like so:

```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid

  fields :first_name, :last_name, :email
end
```

and then, in your code:
```ruby
puts UserBlueprint.render(user) # Output is a JSON string
```

And the output would look like:

```json
{
  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
  "email": "john.doe@some.fake.email.domain",
  "first_name": "John",
  "last_name": "Doe"
}
```

---
</details>


<details>
<summary>Collections</summary>

---

You can also pass a collection object or an array to the render method.

```ruby
puts UserBlueprint.render(User.all)
```

This will result in JSON that looks something like this:

```json
[
  {
    "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
    "email": "john.doe@some.fake.email.domain",
    "first_name": "John",
    "last_name": "Doe"
  },
  {
    "uuid": "733f0758-8f21-4719-875f-743af262c3ec",
    "email": "john.doe.2@some.fake.email.domain",
    "first_name": "John",
    "last_name": "Doe 2"
  }
]
```

---
</details>


<details>
<summary>Renaming</summary>

---

You can rename the resulting JSON keys in both fields and associations by using the `name` option.

```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid

  field :email, name: :login

  association :user_projects, name: :projects
end
```

This will result in JSON that looks something like this:

```json
{
  "uuid": "92a5c732-2874-41e4-98fc-4123cd6cfa86",
  "login": "my@email.com",
  "projects": []
}
```

---
</details>


<details>
<summary>Views</summary>

---

You may define different outputs by utilizing views:
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :email, name: :login

  view :normal do
    fields :first_name, :last_name
  end

  view :extended do
    include_view :normal
    field :address
    association :projects
  end
end
```

Usage:
```ruby
puts UserBlueprint.render(user, view: :extended)
```

Output:
```json
{
  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
  "address": "123 Fake St.",
  "first_name": "John",
  "last_name": "Doe",
  "login": "john.doe@some.fake.email.domain"
}
```

---
</details>


<details>
<summary>Root</summary>

---

You can also optionally pass in a root key to wrap your resulting json in:
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :email, name: :login

  view :normal do
    fields :first_name, :last_name
  end
end
```

Usage:
```ruby
puts UserBlueprint.render(user, view: :normal, root: :user)
```

Output:
```json
{
  "user": {
    "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
    "first_name": "John",
    "last_name": "Doe",
    "login": "john.doe@some.fake.email.domain"
  }
}
```

---
</details>


<details>
<summary>Meta Attributes</summary>

---

You can additionally add meta-data to the json as well:
```ruby
class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :email, name: :login

  view :normal do
    fields :first_name, :last_name
  end
end
```

Usage:
```ruby
json = UserBlueprint.render(user, view: :normal, root: :user, meta: {links: [
  'https://app.mydomain.com',
  'https://alternate.mydomain.com'
]})
puts json
```

Output:
```json
{
  "user": {
    "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
    "first_name": "John",
    "last_name": "Doe",
    "login": "john.doe@some.fake.email.domain"
  },
  "meta": {
    "links": [
      "https://app.mydomain.com",
      "https://alternate.mydomain.com"
    ]
  }
}
```
_NOTE:_ For meta attributes, a [root](#root) is mandatory.

---
</details>

...