### PR TITLE
Exclude a view functionality

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -293,6 +293,44 @@ module Blueprinter
       current_view.include_view(view_name)
     end
 
+    # Specify a view that needs to be excluded from the current view.
+    #
+    # @param view_name [Symbol] the view to exclude from the current view.
+    # PURPOSE: Though excludes can be used to exclude several fields. If all the excluded fields are from a single view, then exclude_view
+    # is a more refined and usable option
+    #
+    # @example Excluding a view from a dervied view
+    #   class UserBlueprint < Blueprinter::Base
+    #     # other code...
+    #     view :normal do
+    #       fields :first_name, :last_name
+    #     end
+    #
+    #     view :descriptive do
+    #        field :get_full_name, name: :name
+    #        view :extended
+    #        exclude_view :normal
+    #     end
+    #
+    #     view :additional_info do
+    #        fields :time_zone, :language
+    #     end
+    #
+    #     view :extended do
+    #       include_view :normal
+    #       include_view :additional_info
+    #       field :description
+    #     end
+    #
+    #     #=> [:first_name, :last_name, :description]
+    #   end
+    #
+    # @return [Array<Symbol>] an array of view names.
+
+    def self.exclude_view(view_name)
+      current_view.exclude_view(view_name)
+    end
+
 
     # Exclude a field that was mixed into the current view.
     #
@@ -313,15 +351,15 @@ module Blueprinter
     def self.exclude(field_name)
       current_view.exclude_field(field_name)
     end
-    
+
     # When mixing multiple views under a single view, some fields may required to be excluded from
     # current view
-    # 
+    #
     # @param [Array<Symbol>] the fields to exclude from the current view.
     #
     # @example Excluding mutiple fields from being included into the current view.
     #   view :normal do
-    #     fields :name,:address,:position, 
+    #     fields :name,:address,:position,
     #           :company, :contact
     #   end
     #   view :special do
@@ -332,7 +370,7 @@ module Blueprinter
     #   => [:name, :company, :contact, :birthday, :joining_anniversary]
     #
     # @return [Array<Symbol>] an array of field names
-    
+
     def self.excludes(*field_names)
       current_view.exclude_fields(field_names)
     end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -3,11 +3,12 @@ module Blueprinter
   class View
     attr_reader :excluded_field_names, :fields, :included_view_names, :name
 
-    def initialize(name, fields: {}, included_view_names: [], excluded_view_names: [])
+    def initialize(name, fields: {}, included_view_names: [], excluded_field_names: [],excluded_view_names: [])
       @name = name
       @fields = fields
       @included_view_names = included_view_names
-      @excluded_field_names = excluded_view_names
+      @excluded_field_names = excluded_field_names
+      @excluded_view_names =  excluded_view_names
     end
 
     def inherit(view)
@@ -22,16 +23,24 @@ module Blueprinter
       view.excluded_field_names.each do |field_name|
         exclude_field(field_name)
       end
+
+      view.excluded_view_names.each do |view_name|
+        exclude_view(view_name)
+      end
     end
 
     def include_view(view_name)
       included_view_names << view_name
     end
 
+    def exclude_view(view_name)
+      excluded_view_names << view_name
+    end
+
     def exclude_field(field_name)
       excluded_field_names << field_name
     end
-    
+
     def exclude_fields(field_names)
       field_names.each do |field_name|
         excluded_field_names << field_name

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -1,7 +1,7 @@
 module Blueprinter
   # @api private
   class View
-    attr_reader :excluded_field_names, :fields, :included_view_names, :name
+    attr_reader :excluded_field_names, :fields, :included_view_names, :name, :excluded_view_names
 
     def initialize(name, fields: {}, included_view_names: [], excluded_field_names: [],excluded_view_names: [])
       @name = name

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -51,7 +51,7 @@ module Blueprinter
 
       views[view_name].excluded_view_names.each do |excluded_view_name|
         next if view_name == excluded_view_name
-        fields.except(views[excluded_view_name].fields.keys)
+        fields.except!(*views[excluded_view_name].fields.keys)
       end
 
       fields

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -49,6 +49,11 @@ module Blueprinter
         fields.delete(name)
       end
 
+      views[view_name].excluded_view_names.each do |excluded_view_name|
+        next if view_name == excluded_view_name
+        fields.except(views[excluded_view_name].fields.keys)
+      end
+
       fields
     end
 

--- a/spec/units/view_spec.rb
+++ b/spec/units/view_spec.rb
@@ -12,6 +12,17 @@ describe '::View' do
     end
   end
 
+  describe '#exclude_view(:view_name)' do
+    it 'show return [:view_name]' do
+      expect(view.exclude_view(:extended)).to eq([:extended])
+    end
+
+    it 'should set #excluded_view_names to [:view_name]' do
+      view.exclude_view(:extended)
+      expect(view.excluded_view_names).to eq([:extended])
+    end
+  end
+
   describe '#exclude_field(:view_name)' do
     it 'should return [:view_name]' do
       expect(view.exclude_field(:last_name)).to eq([:last_name])
@@ -22,16 +33,16 @@ describe '::View' do
     end
   end
 
-  describe '#exclude_fields(:view_name)' do 
-    it 'should return [:view_name]' do 
+  describe '#exclude_fields(:view_name)' do
+    it 'should return [:view_name]' do
       expect(view.exclude_fields([:last_name,:middle_name])).to eq([:last_name,:middle_name])
     end
-    it 'should set #excluded_field_names to [:view_name]' do 
+    it 'should set #excluded_field_names to [:view_name]' do
       view.exclude_fields([:last_name,:middle_name])
       expect(view.excluded_field_names).to eq([:last_name,:middle_name])
     end
   end
-  
+
   describe '#<<(field)' do
     context 'Given a field that does not exist' do
       it('should return field') { expect(view << field).to eq(field) }


### PR DESCRIPTION
Though excludes can be used to exclude several fields. If all the excluded fields are from a single view, then exclude_view is a more refined and usable option

@mcclayton , @philipqnguyen 