### PR TITLE
Add :extractor option to ::association

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -157,7 +157,10 @@ module Blueprinter
 
       field(
         method,
-        options.merge(association: true, extractor: AssociationExtractor.new),
+        options.merge(
+          association: true,
+          extractor: options.fetch(:extractor) { AssociationExtractor.new },
+        ),
         &block
       )
     end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -129,6 +129,25 @@ describe '::Base' do
           end
           it { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
         end
+
+        context 'Given an association :extractor option' do
+          let(:result) { '{"id":' + obj_id + ',"vehicles":[{"make":"SUPER CAR"}]}' }
+          let(:blueprint) do
+            extractor = Class.new(Blueprinter::Extractor) do
+              def extract(association_name, object, _local_options, _options={})
+                object.send(association_name).map { |vehicle| { make: vehicle.make.upcase } }
+              end
+            end
+
+            vehicle_blueprint = Class.new(Blueprinter::Base) { fields :make }
+
+            Class.new(Blueprinter::Base) do
+              field :id
+              association :vehicles, blueprint: vehicle_blueprint, extractor: extractor
+            end
+          end
+          it('returns json derived from a custom extractor') { should eq(result) }
+        end
       end
 
       context "Given association is nil" do


### PR DESCRIPTION
I have the following use case (code simplified for readability):

```ruby
# BlueprinterFinder#find converts :user into UserSerializer

class ApplicationSerializer < Blueprinter::Base
  def self.association(method, options = {}, &block)
    super(
      method,
      { blueprint: BlueprinterFinder.find(method) }.merge(options),
    )
  end
end

class UserSerializer < ApplicationSerializer
  association :contents do |user, options|
    if options[:version]
      user.content_versions.find_by!(version: options[:version])
    else
      user.content_versions.last
    end
  end
end

class UsersController
  def show
    render json: UserSerializer.render(User.find(params[:id]), version: params[:version])
  end
end
```

I also needed something like the following:

```ruby
class CredentialSerializer < ApplicationSerializer
  association :user # pass in credential.version to UserSerializer#render somehow
end

class CredentialsController
  def show
    render json: CredentialSerializer.render(Credential.find(params[:id]))
  end
end
```

To do this, I tried to override the extractor on the association:

```ruby
class MyAssociationExtractor < Blueprinter::AssociationExtractor
  def extract(association_name, object, local_options, options={})
    super(
      association_name,
      object,
      local_options.merge(version: object.version),
      options.except(:extractor),
    )
  end
end

class CredentialSerializer < ApplicationSerializer
  association :user, extractor: MyAssociationExtractor
end
```
 
`::field` allows to override the `:extractor` option, but `::association` does not. This PR introduces the ability to override `:extractor` in associations as well.

Sidenotes/questions:

Is there another way of specifying `local_options` on associations that I may have missed?

I noticed that apart from the `extractor`, the differences between `::association` and `::field` is the option `association: true`. This option seems to be used in `Blueprinter::BaseHelpers#associations`, but I don't see where this helper is used. Is it still required?