### PR TITLE
Dynamic views functionality

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -248,6 +248,7 @@ module Blueprinter
     #
     # @api private
     def self.prepare(object, view_name:, local_options:, root: nil, meta: nil)
+      view_name = view_name.is_a?(Proc) ? view_name.call(object, local_options) : view_name  
       unless view_collection.has_view? view_name
         raise BlueprinterError, "View '#{view_name}' is not defined"
       end
@@ -292,8 +293,8 @@ module Blueprinter
     #   end
     #
     # @return [Array<Symbol>] an array of view names.
-    def self.include_view(view_name)
-      current_view.include_view(view_name)
+    def self.include_view(view_name = nil)
+      current_view.include_view(view_name || Proc.new)
     end
 
 

--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -44,7 +44,10 @@ module Blueprinter
       end
 
       def object_to_hash(object, view_name:, local_options:)
-        view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
+        fields = view_collection.fields_for view_name do |name|
+          name.is_a?(Proc) ? name.call(object, local_options) : name
+        end
+        fields.each_with_object({}) do |field, hash|
           next if field.skip?(field.name, object, local_options)
           hash[field.name] = field.extract(object, local_options)
         end

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -21,9 +21,11 @@ module Blueprinter
     end
 
     def fields_for(view_name)
+      name_cast = block_given? ? Proc.new : nil 
+      view_name = name_cast.call(view_name) if name_cast
       return identifier_fields if view_name == :identifier
 
-      fields = sortable_fields(view_name).values
+      fields = sortable_fields(view_name, &name_cast).values
       sorted_fields = sort_by_definition ? fields : fields.sort_by(&:name)
       identifier_fields + sorted_fields
     end
@@ -42,6 +44,7 @@ module Blueprinter
       fields = views[:default].fields
       fields = merge_fields(fields, views[view_name].fields)
       views[view_name].included_view_names.each do |included_view_name|
+        included_view_name = yield(included_view_name) if block_given?
         if view_name != included_view_name
           fields = merge_fields(fields, sortable_fields(included_view_name))
         end


### PR DESCRIPTION
I changed include_view so it can receive a block to evaluate the view name from object and options. It also works for associations. If association view option is a proc then the view name is evaluated.