### PR TITLE
Remove API private from Extractor

### DIFF
--- a/lib/blueprinter/extractor.rb
+++ b/lib/blueprinter/extractor.rb
@@ -1,5 +1,4 @@
 module Blueprinter
-  # @api private
   class Extractor
     def extract(field_name, object, local_options, options={})
       fail NotImplementedError, "An Extractor must implement #extract"


### PR DESCRIPTION
Custom `Extractor` classes are already being used in production and the Private API warning in the docs is confusing for developers.

https://www.rubydoc.info/gems/blueprinter/Blueprinter/Extractor