### PR TITLE
WIP: Add AMS extractor to associate AMS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,23 @@ Output:
 }
 ```
 
+Associations can also use AMS to render the association:
+
+```ruby
+class UserSerializer < ActiveModelSerializers::Model
+  attributes :id
+end
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :email, name: :login
+
+  view :normal do
+    fields :first_name, :last_name
+    foreign_association :user, serializer_type: :ams
+  end
+end
+```
+
 ---
 </details>
 

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "rake"
   s.add_development_dependency "activerecord", "~> 5.1.2"
+  s.add_development_dependency "active_model_serializers"
   s.add_development_dependency "rspec", "~> 3.7"
   s.add_development_dependency "sqlite3", '~> 1.3.6'
   s.add_development_dependency "yard", "~> 0.9.11"

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -2,6 +2,7 @@ require_relative 'blueprinter_error'
 require_relative 'configuration'
 require_relative 'extractor'
 require_relative 'extractors/association_extractor'
+require_relative 'extractors/ams_extractor'
 require_relative 'extractors/auto_extractor'
 require_relative 'extractors/block_extractor'
 require_relative 'extractors/hash_extractor'
@@ -160,6 +161,19 @@ module Blueprinter
         options.merge(
           association: true,
           extractor: options.fetch(:extractor) { AssociationExtractor.new },
+        ),
+        &block
+      )
+    end
+
+    def self.foreign_association(method, options = {}, &block)
+      raise BlueprinterError, 'ams serializer is required' unless options[:serializer_type] == :ams
+
+      field(
+        method,
+        options.merge(
+          association: true,
+          extractor: options.fetch(:extractor) { AMSExtractor.new },
         ),
         &block
       )

--- a/lib/blueprinter/extractors/ams_extractor.rb
+++ b/lib/blueprinter/extractors/ams_extractor.rb
@@ -1,0 +1,7 @@
+module Blueprinter
+  class AMSExtractor < Extractor
+    def extract(association_name, object, local_options, options={})
+      ActiveModelSerializers::SerializableResource.new(object.public_send(association_name)).as_json
+    end
+  end
+end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -1,6 +1,7 @@
 require 'activerecord_helper'
 require 'ostruct'
 require_relative 'shared/base_render_examples'
+require 'active_model_serializers'
 
 describe '::Base' do
   let(:blueprint_with_block) do
@@ -104,6 +105,21 @@ describe '::Base' do
             expect(JSON.parse(blueprint.render(vehicle))["user"]).to eq({"id"=>obj.id})
           end
         end
+
+        context "Given association with active model serializer" do
+          class UserSerializer < ActiveModelSerializers::Model
+            attributes :id
+          end
+          let(:blueprint) do
+            Class.new(Blueprinter::Base) do
+              foreign_association :user, serializer_type: :ams
+            end
+          end
+          it "should render the association with dynamic blueprint" do
+            expect(JSON.parse(blueprint.render(vehicle))["user"]["id"]).to eq(obj.id)
+          end
+        end
+
         context 'Given block is passed' do
           let(:blueprint) do
             vehicle_blueprint = Class.new(Blueprinter::Base) do


### PR DESCRIPTION
Now you should be able to integrate your AMS models with your blueprints as long as the blueprint is the top level object. This should aid in migrating to blueprint without having to migrate all associated objects.

It should be very easy to add support for other `foreign_association` types in the future if people have trouble migrating from another framework.