### PR TITLE
Draft release for v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.19.0  - 2019/07/24
+* 🚀 [FEATURE] Added ability to specify transformers for Blueprinter views to further process the resulting hash before serialization. [#164](https://github.com/procore/blueprinter/pull/164). Thanks to [@amalarayfreshworks](https://github.com/amalarayfreshworks).
+
 ## 0.18.0  - 2019/05/29
 
 * ⚠️ [DEPRECATION] :if/:unless procs with two arguments are now deprecated. *These procs now take in three arguments (field_name, obj, options) instead of just (obj, options).*

--- a/README.md
+++ b/README.md
@@ -661,6 +661,53 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 
 
 <details>
+<summary>Transform Classes</summary>
+
+---
+
+Blueprinter provides the ability to specify `transform`s on views, which will enable
+the processing and transforming of resulting view field hashes prior to serialization.
+
+Use `transform` to specify one transformer to be included for serialization.
+A transformer is a class, extending `Blueprinter::Transformer` and implementing the `transform` method.
+Whatever is returned from this `transform` method will end up being the resulting hash passed to serialization.
+
+#### Example
+
+Create a Transform class extending from `Blueprinter::Transformer`
+```ruby
+class DynamicFieldTransformer < Blueprinter::Transformer
+  def transform(hash, object, options)
+    hash.merge!(object.dynamic_fields)
+  end
+end
+```
+
+```ruby
+class User
+  def custom_columns
+    self.dynamic_fields #which is an array of some columns
+  end
+
+  def custom_fields
+    custom_columns.each_with_object({}){|col,result|  result[col] = self.send(col)}
+  end
+end
+```
+
+Then specify the transform to use for the view.
+```ruby
+class UserBlueprint < Blueprinter::Base
+  fields :first_name, :last_name
+  transform DynamicTransformer
+end
+```
+
+---
+</details>
+
+
+<details>
 <summary>Sorting Fields</summary>
 
 ---

--- a/README.md
+++ b/README.md
@@ -665,8 +665,8 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 
 ---
 
-Blueprinter provides the ability to specify `transform`s on views, which will enable
-the processing and transforming of resulting view field hashes prior to serialization.
+Blueprinter provides the ability to specify `transform`s on views, which enable further
+processing and transforming of resulting view field hashes prior to serialization.
 
 Use `transform` to specify one transformer to be included for serialization.
 A transformer is a class, extending `Blueprinter::Transformer` and implementing the `transform` method.

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.18.0'
+  VERSION = '0.19.0'
 end


### PR DESCRIPTION
## 0.19.0  - 2019/07/24
* 🚀 [FEATURE] Added ability to specify transformers for Blueprinter views to further process the resulting hash before serialization. [#164](https://github.com/procore/blueprinter/pull/164). Thanks to [@amalarayfreshworks](https://github.com/amalarayfreshworks).


### Readme Section
<details>
<summary>Transform Classes</summary>

---

Blueprinter provides the ability to specify `transform`s on views, which enable further
processing and transforming of resulting view field hashes prior to serialization.

Use `transform` to specify one transformer to be included for serialization.
A transformer is a class, extending `Blueprinter::Transformer` and implementing the `transform` method.
Whatever is returned from this `transform` method will end up being the resulting hash passed to serialization.

#### Example

Create a Transform class extending from `Blueprinter::Transformer`
```ruby
class DynamicFieldTransformer < Blueprinter::Transformer
  def transform(hash, object, options)
    hash.merge!(object.dynamic_fields)
  end
end
```

```ruby
class User
  def custom_columns
    self.dynamic_fields #which is an array of some columns
  end
  def custom_fields
    custom_columns.each_with_object({}){|col,result|  result[col] = self.send(col)}
  end
end
```

Then specify the transform to use for the view.
```ruby
class UserBlueprint < Blueprinter::Base
  fields :first_name, :last_name
  transform DynamicTransformer
end
```

---
</details>