### PR TITLE
Moving away from hashed parameters to regular ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.19.1  - 2019/08/13
+* 💅 [ENHANCEMENT] Moved away from hash based named parameters to reduce object allocations. [#175](https://github.com/procore/blueprinter/pull/175). Thanks to [@ritikesh](https://github.com/ritikesh).
+
 ## 0.19.0  - 2019/07/24
 * 🚀 [FEATURE] Added ability to specify transformers for Blueprinter views to further process the resulting hash before serialization. [#164](https://github.com/procore/blueprinter/pull/164). Thanks to [@amalarayfreshworks](https://github.com/amalarayfreshworks).
 

--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Blueprinter is a JSON Object Presenter for Ruby that takes business objects and breaks them down into simple hashes and serializes them to JSON. It can be used in Rails in place of other serializers (like JBuilder or ActiveModelSerializers). It is designed to be simple, direct, and performant."
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "CHANGELOG.md", "MIT-LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["lib/**/*", "MIT-LICENSE", "README.md"]
 
   s.required_ruby_version = '>= 2.2.2'
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -248,7 +248,7 @@ module Blueprinter
     # so we rename it for clarity
     #
     # @api private
-    def self.prepare(object, view_name:, local_options:, root: nil, meta: nil)
+    def self.prepare(object, view_name, local_options, root= nil, meta= nil)
       unless view_collection.has_view? view_name
         raise BlueprinterError, "View '#{view_name}' is not defined"
       end

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -10,7 +10,7 @@ module Blueprinter
       return default_value(options) if value.nil?
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)
-      blueprint.prepare(value, view_name: view, local_options: local_options)
+      blueprint.prepare(value, view, local_options)
     end
 
     private

--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -16,20 +16,16 @@ module Blueprinter
         root = options.delete(:root)
         meta = options.delete(:meta)
         validate_root_and_meta(root, meta)
-        prepare(object, view_name: view_name, local_options: options, root: root, meta: meta)
+        prepare(object, view_name, options, root, meta)
       end
 
       def prepare_data(object, view_name, local_options)
         if array_like?(object)
           object.map do |obj|
-            object_to_hash(obj,
-                          view_name: view_name,
-                          local_options: local_options)
+            object_to_hash(obj, view_name, local_options)
           end
         else
-          object_to_hash(object,
-                        view_name: view_name,
-                        local_options: local_options)
+          object_to_hash(object, view_name, local_options)
         end
       end
 
@@ -43,7 +39,7 @@ module Blueprinter
         subclass.send(:view_collection).inherit(view_collection)
       end
 
-      def object_to_hash(object, view_name:, local_options:)
+      def object_to_hash(object, view_name, local_options)
         result_hash = view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
           next if field.skip?(field.name, object, local_options)
            hash[field.name] = field.extract(object, local_options)

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.19.0'
+  VERSION = '0.19.1'
 end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -3,7 +3,8 @@ module Blueprinter
   class View
     attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers
 
-    def initialize(name, fields: {}, included_view_names: [], excluded_view_names: [],transformers: [])
+    def initialize(name, fields = {}, included_view_names = [], 
+        excluded_view_names = [], transformers = [])
       @name = name
       @fields = fields
       @included_view_names = included_view_names

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -3,13 +3,12 @@ module Blueprinter
   class View
     attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers
 
-    def initialize(name, fields = {}, included_view_names = [], 
-        excluded_view_names = [], transformers = [])
+    def initialize(name)
       @name = name
-      @fields = fields
-      @included_view_names = included_view_names
-      @excluded_field_names = excluded_view_names
-      @transformers =  transformers
+      @fields = {}
+      @included_view_names = []
+      @excluded_field_names = []
+      @transformers =  []
     end
 
     def inherit(view)

--- a/lib/tasks/blueprinter_tasks.rake
+++ b/lib/tasks/blueprinter_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :blueprinter do
-#   # Task goes here
-# end


### PR DESCRIPTION
This is to reduce the number of object(hashes) allocations. The intended functionality can be achieved using named n-ary arguments as well.