### PR TITLE
Improve .render performance

### DIFF
--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -10,7 +10,7 @@ class Blueprinter::Field
   end
 
   def extract(object, local_options)
-    extractor.extract(method, object, local_options, options)
+    @extracted ||= extractor.extract(method, object, local_options, options)
   end
 
   def skip?(field_name, object, local_options)

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -23,9 +23,13 @@ module Blueprinter
     def fields_for(view_name)
       return identifier_fields if view_name == :identifier
 
-      fields = sortable_fields(view_name).values
-      sorted_fields = sort_by_definition ? fields : fields.sort_by(&:name)
-      identifier_fields + sorted_fields
+      @fields_for ||= Hash.new do |hash, key|
+        fields = sortable_fields(key).values
+        sorted_fields = sort_by_definition ? fields : fields.sort_by(&:name)
+        hash[key] = identifier_fields + sorted_fields
+      end
+
+      @fields_for[view_name]
     end
 
     def transformers(view_name)


### PR DESCRIPTION
I used `ruby-prof` to analyze the time spent in methods and memoized the most expensive ones. There is a space tradeoff but it may be worth the time gains.

[Benchmarking script](https://gist.github.com/cagmz/d839abe387b67fbdce7ffa51b48e0ab7) 

[Full output from script](https://gist.github.com/cagmz/d209700ed6953711f8d5bf3d2d490cbf)

[Master Prepared Object Ruby prof call tree](https://vigilant-wing-47b7a9.netlify.com)
[Fork Prepared Object Ruby prof call tree](https://vibrant-yalow-3beb55.netlify.com)

[Master ActiveRecord Ruby prof call tree](https://angry-yonath-409ba5.netlify.com)
[Fork ActiveRecord Ruby prof call tree](https://festive-ramanujan-f292d4.netlify.com)

# IPS

|        | IPS (object) | IPS (ActiveRecord) |
| ------ | ------------ | ------------------ |
| master | 11776.2      | 10003.1            |
| fork   | 12880.6      | 10821.8            |
| diff   | + 9.378%     | + 8.184%           |

# Memory

|        | Memory allocated (object)       | Memory allocated (ActiveRecord) |
|--------|---------------------------------|---------------------------------|
| master | 53278996 bytes (712340 objects) | 44599596 bytes (594605 objects) |
| fork   | 51929108 bytes (694292 objects) | 48724236 bytes (649595 objects) |
| diff   | - 2.534%                        | + 9.248 %                       |
