### PR TITLE
Modify Extractor access control

### DIFF
--- a/lib/blueprinter/extractor.rb
+++ b/lib/blueprinter/extractor.rb
@@ -1,5 +1,4 @@
 module Blueprinter
-  # @api private
   class Extractor
     def extract(field_name, object, local_options, options={})
       fail NotImplementedError, "An Extractor must implement #extract"

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class AssociationExtractor < Extractor
     def initialize
       @extractor = AutoExtractor.new

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class AutoExtractor < Extractor
     def initialize
       @hash_extractor = HashExtractor.new

--- a/lib/blueprinter/extractors/block_extractor.rb
+++ b/lib/blueprinter/extractors/block_extractor.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class BlockExtractor < Extractor
     def extract(field_name, object, local_options, options = {})
       options[:block].call(object, local_options)

--- a/lib/blueprinter/extractors/hash_extractor.rb
+++ b/lib/blueprinter/extractors/hash_extractor.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class HashExtractor < Extractor
     def extract(field_name, object, _local_options, _options = {})
       object[field_name]

--- a/lib/blueprinter/extractors/public_send_extractor.rb
+++ b/lib/blueprinter/extractors/public_send_extractor.rb
@@ -1,4 +1,5 @@
 module Blueprinter
+  # @api private
   class PublicSendExtractor < Extractor
     def extract(field_name, object, local_options, options = {})
       object.public_send(field_name)


### PR DESCRIPTION
Custom Extractor classes are already being used in production and the Private API warning in the docs is confusing for developers.

https://www.rubydoc.info/gems/blueprinter/Blueprinter/Extractor

Also makes prebuilt classes inheriting from Extractor private (from a [previous PR comment](https://github.com/procore/blueprinter/pull/165#issuecomment-532896106)).