### PR TITLE
Ability to include multiple views in a single method call

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -336,11 +336,11 @@ module Blueprinter
     end
 
 
-    # Specify another view that should be mixed into the current view.
+    # Specify additional views that should be mixed into the current view.
     #
-    # @param view_name [Symbol] the view to mix into the current view.
+    #  @param view_name [Array<Symbol>] the views to mix into the current view.
     #
-    # @example Including a normal view into an extended view.
+    # @example Including the normal and special views into an extended view.
     #   class UserBlueprint < Blueprinter::Base
     #     # other code...
     #     view :normal do

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -336,6 +336,34 @@ module Blueprinter
     end
 
 
+    # Specify another view that should be mixed into the current view.
+    #
+    # @param view_name [Symbol] the view to mix into the current view.
+    #
+    # @example Including a normal view into an extended view.
+    #   class UserBlueprint < Blueprinter::Base
+    #     # other code...
+    #     view :normal do
+    #       fields :first_name, :last_name
+    #     end
+    #     view :special do 
+    #       fields :birthday, :company
+    #     end 
+    #     view :extended do
+    #       include_views :normal, :special # include fields specified from above.
+    #       field :description
+    #     end
+    #     #=> [:first_name, :last_name, :birthday, :company, :description]
+    #   end
+    #
+    # @return [Array<Symbol>] an array of view names.
+
+
+    def self.include_views(*view_names)
+        current_view.include_views(view_names)
+    end 
+
+
     # Exclude a field that was mixed into the current view.
     #
     # @param field_name [Symbol] the field to exclude from the current view.

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -33,6 +33,12 @@ module Blueprinter
       included_view_names << view_name
     end
 
+    def include_views(view_names)
+      view_names.each do |view_name|
+        included_view_names << view_name
+      end
+    end 
+
     def exclude_field(field_name)
       excluded_field_names << field_name
     end

--- a/spec/units/view_spec.rb
+++ b/spec/units/view_spec.rb
@@ -12,6 +12,16 @@ describe '::View' do
     end
   end
 
+  describe '#include_views(:view_name)' do
+    it 'should return [:view_name]' do
+      expect(view.include_views([:normal, :special])).to eq([:normal, :special])
+    end
+    it 'should set #included_view_names to [:view_name]' do
+      view.include_views([:normal, :special])
+      expect(view.included_view_names).to eq([:normal, :special])
+    end
+  end
+
   describe '#exclude_field(:view_name)' do
     it 'should return [:view_name]' do
       expect(view.exclude_field(:last_name)).to eq([:last_name])


### PR DESCRIPTION
Created a new method called include_views and pass multiple views as arguments, which will render all the passed views in the blueprint.  

before:
```
include_view :user_summary
include_view :org_summary
```

Now:
```
include_views :user_summary,  :org_summary
```