### PR TITLE
Honor default option for has_many associations

### DIFF
--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -8,7 +8,8 @@ module Blueprinter
     def extract(association_name, object, local_options, options={})
       options_without_default = options.reject { |k,_| k == :default }
       value = @extractor.extract(association_name, object, local_options, options_without_default)
-      return default_value(options) if value.nil?
+      return default_value(options) if value.nil? || (value.blank? && value.is_a?(ActiveRecord::Associations::CollectionProxy))
+      
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)
       blueprint.prepare(value, view_name: view, local_options: local_options)

--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -11,7 +11,9 @@ module Blueprinter
     def extract(field_name, object, local_options, options = {})
       extraction = extractor(object, options).extract(field_name, object, local_options, options)
       value = @datetime_formatter.format(extraction, options)
-      value.nil? ? default_value(options) : value
+      return default_value(options) if value.nil? || (value.blank? && value.is_a?(ActiveRecord::Associations::CollectionProxy))
+
+      value
     end
 
     private

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -236,11 +236,6 @@ describe '::Base' do
       end
 
       context "Given association is empty" do
-        before do
-          empty_relation = obj.vehicles
-          expect(obj).to receive(:vehicles).and_return(empty_relation)
-        end
-  
         context "Given default association value is provided and is empty" do
           let(:result) { '{"id":' + obj_id + ',"vehicles":null}' }
           

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -234,6 +234,31 @@ describe '::Base' do
           end
         end
       end
+
+      context "Given association is empty" do
+        before do
+          empty_relation = obj.vehicles
+          expect(obj).to receive(:vehicles).and_return(empty_relation)
+        end
+  
+        context "Given default association value is provided and is empty" do
+          let(:result) { '{"id":' + obj_id + ',"vehicles":null}' }
+          
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              fields :make
+            end
+            
+            Class.new(Blueprinter::Base) do
+              identifier :id
+              association :vehicles, 
+                          blueprint: vehicle_blueprint,
+                          default: nil
+            end
+          end
+          it('should render the default value provided for the association') { should eq(result) }
+        end
+      end
     end
   end
   describe '::render_as_hash' do


### PR DESCRIPTION
Has many associations return an empty relation instead of a nil value so the default option was not honored:

`return default_value(options) if value.nil?`

I added another condition to it:

`return default_value(options) if value.nil? || (value.blank? && value.is_a?(ActiveRecord::Associations::CollectionProxy))`