### PR TITLE
Add before_render callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,47 @@ _NOTE:_ The field-level setting overrides the global config setting (for the fie
 
 
 <details>
+<summary>before_render callbacks</summary>
+
+---
+
+Callback called before fields are serialized. This can be used to compute
+values used in your fields and storing computed valued inside the
+options hash.
+
+#### Example
+
+```ruby
+class UserBlueprint < Blueprinter::Base
+  before_render do |object, options|
+    options[:address] = "REDACTED" if options[:redact]
+  end
+
+  identifier :uuid
+  field :address { |object, options| options[:address] || object.address }
+end
+```
+
+Useage:
+
+```ruby
+puts UserBlueprint.render(user, view: :extended, redact: true)
+```
+
+Output:
+
+```ruby
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+  "address": "REDACTED"
+}
+```
+
+---
+</details>
+
+
+<details>
 <summary>Transform Classes</summary>
 
 ---

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -1,3 +1,4 @@
+require_relative 'before_render'
 require_relative 'blueprinter_error'
 require_relative 'configuration'
 require_relative 'empty_types'
@@ -278,6 +279,26 @@ module Blueprinter
       end
     end
 
+    # Callback called before fields are serialized. This can be used to compute
+    # values used in your fields and storing computed valued inside the
+    # options hash.
+    #
+    # @yield [object, options] The object and the options passed to render are
+    #   yielded to the block.
+    #
+    # @example Redacting address conditionally.
+    #   class UserBlueprint < Blueprinter::Base
+    #     before_render do |object, options|
+    #       options[:address] = "REDACTED" if options[:redact]
+    #     end
+    #
+    #     field :address { |object, options| options[:address] || object.address }
+    #   end
+    #
+    # @return [BeforeRender] a BeforeRender object.
+    def self.before_render(&block)
+      current_view.add_before_render(BeforeRender.new(block))
+    end
 
 
     # Specify one transformer to be included for serialization.

--- a/lib/blueprinter/before_render.rb
+++ b/lib/blueprinter/before_render.rb
@@ -1,0 +1,14 @@
+# @api private
+module Blueprinter
+  class BeforeRender
+    attr_reader :block
+    
+    def initialize(block)
+      @block = block
+    end
+
+    def call(object, options)
+      block.call(object, options)
+    end
+  end
+end

--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -41,10 +41,15 @@ module Blueprinter
       end
 
       def object_to_hash(object, view_name:, local_options:)
+        view_collection.before_renders(view_name).each do |before_render|
+          before_render.call(object, local_options)
+        end
+
         result_hash = view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
           next if field.skip?(field.name, object, local_options)
            hash[field.name] = field.extract(object, local_options)
         end
+
         view_collection.transformers(view_name).each do |transformer|
            transformer.transform(result_hash,object,local_options)
         end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -1,10 +1,11 @@
 module Blueprinter
   # @api private
   class View
-    attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers
+    attr_reader :excluded_field_names, :fields, :included_view_names, :name, :before_renders, :transformers
 
-    def initialize(name, fields: {}, included_view_names: [], excluded_view_names: [],transformers: [])
+    def initialize(name, fields: {}, included_view_names: [], excluded_view_names: [], before_renders: [], transformers: [])
       @name = name
+      @before_renders = before_renders
       @fields = fields
       @included_view_names = included_view_names
       @excluded_field_names = excluded_view_names
@@ -27,6 +28,10 @@ module Blueprinter
       view.transformers.each do |transformer|
         self.add_transformer(transformer)
       end
+
+      view.before_renders.each do |before_render|
+        add_before_render(before_render)
+      end
     end
 
     def include_view(view_name)
@@ -47,6 +52,10 @@ module Blueprinter
       field_names.each do |field_name|
         excluded_field_names << field_name
       end
+    end
+
+    def add_before_render(before_render)
+      before_renders << before_render
     end
 
     def add_transformer(custom_transformer)

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -20,6 +20,10 @@ module Blueprinter
       views.has_key? view_name
     end
 
+    def before_renders(view_name)
+      (views[:default].before_renders + views[view_name].before_renders).uniq
+    end
+
     def fields_for(view_name)
       return identifier_fields if view_name == :identifier
 


### PR DESCRIPTION
Adds `before_render` callbacks before the blueprint is serialized. My use case is to load a database record relevant to the blueprint when rendered.

The syntax looks like the following:
```ruby
class UserBlueprint < Blueprinter::Base
  before_render do |object, options|
    options[:address] = "REDACTED" if options[:redact]
  end
  identifier :uuid
  field :address { |object, options| options[:address] || object.address }
end
```

In this example, address is set to the string `REDACTED` if the `redact` field is passed into `options`.

It also supports `before_render` callbacks nested in `view`s:
```ruby
class UserBlueprint < Blueprinter::Base
  before_render do |object, options|
    options[:address] = object.address.country if options[:redact]
  end
  identifier :uuid
  field :address { |object, options| options[:address] || object.address }

  view :medium_privacy do
    before_render do |object, options|
      options[:address] = object.address.city + ", " + options[:address]
    end
  end
end
```

In which case, the call `UserBlueprint.render(user, view: :medium_privacy, redact: true)` output something like this:
```ruby
{
  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
  "address": "Ottawa, Canada"
}
```