### PR TITLE
explicitly track field definition order when used to sort output fields

### DIFF
--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -427,6 +427,7 @@ module Blueprinter
     # @return [View] a Blueprinter::View object
     def self.view(view_name)
       @current_view = view_collection[view_name]
+      view_collection[:default].track_definition_order({view_name => nil})
       yield
       @current_view = view_collection[:default]
     end

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -427,7 +427,7 @@ module Blueprinter
     # @return [View] a Blueprinter::View object
     def self.view(view_name)
       @current_view = view_collection[view_name]
-      view_collection[:default].track_definition_order({view_name => nil})
+      view_collection[:default].track_definition_order(view_name)
       yield
       @current_view = view_collection[:default]
     end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -1,5 +1,6 @@
 module Blueprinter
   # @api private
+  DefinitionPlaceholder = Struct.new :name, :for_a_view?
   class View
     attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers, :definition_order
 
@@ -13,9 +14,9 @@ module Blueprinter
       @sort_by_definition = Blueprinter.configuration.sort_fields_by.eql?(:definition)
     end
 
-    def track_definition_order(method)
+    def track_definition_order(method, is_view = true)
       if @sort_by_definition
-        @definition_order << method
+        @definition_order << DefinitionPlaceholder.new(method, is_view)
       end
     end
 
@@ -38,13 +39,13 @@ module Blueprinter
     end
 
     def include_view(view_name)
-      track_definition_order(view_name => nil)
+      track_definition_order(view_name)
       included_view_names << view_name
     end
 
     def include_views(view_names)
       view_names.each do |view_name|
-        track_definition_order(view_name => nil)
+        track_definition_order(view_name)
         included_view_names << view_name
       end
     end
@@ -64,7 +65,7 @@ module Blueprinter
     end
 
     def <<(field)
-      track_definition_order(field.name)
+      track_definition_order(field.name,false)
       fields[field.name] = field
     end
   end

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -1,6 +1,6 @@
 module Blueprinter
   # @api private
-  DefinitionPlaceholder = Struct.new :name, :for_a_view?
+  DefinitionPlaceholder = Struct.new :name, :view?
   class View
     attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers, :definition_order
 

--- a/lib/blueprinter/view.rb
+++ b/lib/blueprinter/view.rb
@@ -1,7 +1,7 @@
 module Blueprinter
   # @api private
   class View
-    attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers
+    attr_reader :excluded_field_names, :fields, :included_view_names, :name, :transformers, :definition_order
 
     def initialize(name, fields: {}, included_view_names: [], excluded_view_names: [],transformers: [])
       @name = name
@@ -9,6 +9,14 @@ module Blueprinter
       @included_view_names = included_view_names
       @excluded_field_names = excluded_view_names
       @transformers =  transformers
+      @definition_order = []
+      @sort_by_definition = Blueprinter.configuration.sort_fields_by.eql?(:definition)
+    end
+
+    def track_definition_order(method)
+      if @sort_by_definition
+        @definition_order << method
+      end
     end
 
     def inherit(view)
@@ -30,11 +38,13 @@ module Blueprinter
     end
 
     def include_view(view_name)
+      track_definition_order(view_name => nil)
       included_view_names << view_name
     end
 
     def include_views(view_names)
       view_names.each do |view_name|
+        track_definition_order(view_name => nil)
         included_view_names << view_name
       end
     end
@@ -54,6 +64,7 @@ module Blueprinter
     end
 
     def <<(field)
+      track_definition_order(field.name)
       fields[field.name] = field
     end
   end

--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -68,7 +68,7 @@ module Blueprinter
     # view_name_filter allows to follow definition order all the way down starting from the view_name given to sort_by_def()
     # but include no others at the top-level
     def add_to_ordered_fields(ordered_fields, definition, fields, view_name_filter = nil)
-      if definition.for_a_view?
+      if definition.view?
         if view_name_filter.nil? || view_name_filter == definition.name
           views[definition.name].definition_order.each { |_definition| add_to_ordered_fields(ordered_fields, _definition, fields) }
         end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -460,4 +460,171 @@ shared_examples 'Base::render' do
     end
     it('returns json with values derived from options') { should eq(result) }
   end
+
+  context "Ordering of fields from inside a view by definition" do
+    before { Blueprinter.configure { |config| config.sort_fields_by = :definition } }
+    after { reset_blueprinter_config! }
+
+
+    let(:view_default) do
+      Class.new(Blueprinter::Base) do
+        view :expanded do
+          field :company
+        end
+        field :first_name
+        field :last_name
+      end
+    end
+    let(:view_default_keys) { [:first_name, :last_name] }
+
+    let(:view_first) do
+      Class.new(Blueprinter::Base) do
+        view :expanded do
+          field :company
+        end
+        identifier :id
+        field :first_name
+        field :last_name
+      end
+    end
+    let(:view_first_keys) { [:id, :company, :first_name, :last_name] }
+
+    let(:view_last) do
+      Class.new(Blueprinter::Base) do
+        field :first_name
+        field :last_name
+        view :expanded do
+          field :company
+        end
+      end
+    end
+    let(:view_last_keys) { [:first_name, :last_name , :company] }
+
+    let(:view_middle) do
+      Class.new(Blueprinter::Base) do
+        field :first_name
+        view :expanded do
+          field :company
+        end
+        field :last_name
+      end
+    end
+    let(:view_middle_keys) { [:first_name, :company, :last_name] }
+
+    let(:view_middle_include) do
+      Class.new(Blueprinter::Base) do
+        field :first_name
+        view :active do
+          field :active
+        end
+        view :expanded do
+          field :company
+          include_view :active
+        end
+        field :last_name
+      end
+    end
+    let(:view_middle_include_keys) { [:first_name, :company, :active, :last_name] }
+
+    let(:view_middle_includes) do
+      Class.new(Blueprinter::Base) do
+        field :first_name
+        view :active do
+          field :active
+        end
+        view :description do
+          field :description
+        end
+        view :expanded do
+          field :company
+          include_views :active, :description
+        end
+        field :last_name
+      end
+    end
+    let(:view_middle_includes_keys) { [:first_name, :company, :active, :description, :last_name] }
+
+    let(:view_middle_and_last) do
+      Class.new(Blueprinter::Base) do
+        view :description do
+          field :description
+        end
+        view :active do
+          field :active
+          field :deleted_at
+        end
+
+        field :first_name
+        view :expanded do
+          field :company
+          include_view :active
+        end
+        field :last_name
+        view :expanded do
+          include_view :description
+        end
+      end
+    end
+    # all :expanded blocks' fields got into the order at the point where the :expanded block was entered the first time
+    # bc of depth first traversal at sorting time and not tracking state of @definition_order at time of each block entry
+    let(:view_middle_and_last_keys) { [:first_name, :company, :active, :deleted_at, :description, :last_name] }
+
+    subject { blueprint.render_as_hash(object_with_attributes, view: :expanded).keys }
+
+    context "Middle" do
+      let(:blueprint) { view_middle }
+      it "order preserved" do
+        should(eq(view_middle_keys))
+      end
+    end
+    context "First" do
+      let(:blueprint) { view_first }
+      it "order preserved" do
+        should(eq(view_first_keys))
+      end
+    end
+    context "Last" do
+      let(:blueprint) { view_last }
+      it "order preserved" do
+        should(eq(view_last_keys))
+      end
+    end
+    context "include_view" do
+      let(:blueprint) { view_middle_include }
+      it "order preserved" do
+        should(eq(view_middle_include_keys))
+      end
+    end
+    context "include_views" do
+      let(:blueprint) { view_middle_includes }
+      it "order preserved" do
+        should(eq(view_middle_includes_keys))
+      end
+    end
+    context "Middle and Last" do
+      let(:blueprint) { view_middle_and_last }
+      it "order preserved" do
+        should(eq(view_middle_and_last_keys))
+      end
+    end
+
+    context "Default" do
+      context "explicit" do
+        subject { blueprint.render_as_hash(object_with_attributes, view: :default).keys }
+        let(:blueprint) { view_default }
+        it "order preserved" do
+          should(eq(view_default_keys))
+        end
+      end
+      context "implicit" do
+        subject { blueprint.render_as_hash(object_with_attributes).keys }
+        let(:blueprint) { view_default }
+        it "order preserved" do
+          should(eq(view_default_keys))
+        end
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
This is a fix for #172.  Thanks to https://github.com/procore/blueprinter/pull/185 I saw that the problem comes from how fields are merged at render time. Hash insertion order was not quite enough but probably could have been made to work with some more bookkeeping during the field definition which would then be taken account of in ```ViewCollection``` ```#sortable_fields```and ```#merge_fields```

Rather than increasing the amount of fancy footwork involved with merging hashes, each ```View``` now builds up an ordering at definition time which is traversed at render time.

One edge case to note, is that if for some reason a ```View``` is defined over multiple block yields, the output order will be as if all those fields were added inside the first one. This seems no worse than the current situation where all those fields would be grouped together in an incorrect location.