### PR TITLE
set rspec-rails <= 4.0 to support ruby 2.2

### DIFF
--- a/blueprinter.gemspec
+++ b/blueprinter.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "activerecord", "~> 5.1.2"
   s.add_development_dependency "rspec", "~> 3.7"
+  # rspec-rails >= 4.0.0 does not support ruby 2.2
+  s.add_development_dependency 'rspec-rails', '< 4.0.0'
   s.add_development_dependency "sqlite3", '~> 1.3.6'
   s.add_development_dependency "yard", "~> 0.9.11"
   s.add_development_dependency "ammeter", "~> 1.1.4"


### PR DESCRIPTION
Connected with https://github.com/procore/blueprinter/pull/208