### PR TITLE
Fix Changelog timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 ## 0.23.4  - 2020/4/28
 * 🚀 [FEATURE] Public class method `has_view?` on Blueprinter::Base subclasses introduced in [#213](https://github.com/procore/blueprinter/pull/213). Thanks to [@spencerneste](https://github.com/spencerneste).
 
-## 0.23.3  - 2019/4/7
+## 0.23.3  - 2020/4/7
 * 🐛 [BUGFIX] Fixes issue where `exclude` fields in deeply nested views were not respected. Resolved issue [207](https://github.com/procore/blueprinter/issues/207) in [#208](https://github.com/procore/blueprinter/pull/208) by [@tpltn](https://github.com/tpltn).
 
-## 0.23.2  - 2019/3/16
+## 0.23.2  - 2020/3/16
 * 🐛 [BUGFIX] Fixes issue where fields "bled" into other views due to merge side-effects. Resolved issue [205](https://github.com/procore/blueprinter/issues/205) in [#204](https://github.com/procore/blueprinter/pull/204) by [@trevorrjohn](https://github.com/trevorrjohn).
 
-## 0.23.1  - 2019/3/13
+## 0.23.1  - 2020/3/13
 * 🐛 [BUGFIX] Fixes #172 where views would unintentionally ignore `sort_fields_by: :definition` configuration. Resolved in [#197](https://github.com/procore/blueprinter/pull/197) by [@wlkrw](https://github.com/wlkrw).
 
-## 0.23.0  - 2019/1/31
+## 0.23.0  - 2020/1/31
 * 🚀 [FEATURE] Configurable default extractor introduced in [#198](https://github.com/procore/blueprinter/pull/198) by [@wlkrw](https://github.com/wlkrw). You can now set a default extractor like so:
 ```
 Blueprinter.configure do |config|


### PR DESCRIPTION
The Year for all 0.23.* releases but the 0.23.4 release is 2019 but it should be 2020.