### PR TITLE
Enable passing options between blueprints via associations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.23.5  - 2020/6/22
+* 🚀 [FEATURE] Add an `options` option to associations to facilitate passing options from one blueprint to another. [#220](https://github.com/procore/blueprinter/pull/220). Thanks to [@mcclayton](https://github.com/mcclayton).
+
 ## 0.23.4  - 2020/4/28
 * 🚀 [FEATURE] Public class method `has_view?` on Blueprinter::Base subclasses introduced in [#213](https://github.com/procore/blueprinter/pull/213). Thanks to [@spencerneste](https://github.com/spencerneste).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.23.5  - 2020/6/22
+## 0.24.0  - 2020/6/22
 * 🚀 [FEATURE] Add an `options` option to associations to facilitate passing options from one blueprint to another. [#220](https://github.com/procore/blueprinter/pull/220). Thanks to [@mcclayton](https://github.com/mcclayton).
 
 ## 0.23.4  - 2020/4/28

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ For example:
 class VehicleBlueprint < Blueprinter::Base
   identifier :uuid
   field :full_name do |vehicle, options|
-    "#{vehicle.model} #{options[:trim]}}"
+    "#{vehicle.model} #{options[:trim]}"
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,26 @@ Output:
 }
 ```
 
+It is also possible to pass options from one Blueprint to another via an association.
+For example:
+```ruby
+class VehicleBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :full_name do |vehicle, options|
+    "#{vehicle.model} #{options[:trim]}}"
+  end
+end
+
+class DriverBlueprint < Blueprinter::Base
+  identifier :uuid
+
+  view :normal do
+    fields :first_name, :last_name
+    association :vehicles, blueprint: vehicle_blueprint, options: { trim: 'LX' }
+  end
+end
+```
+
 ---
 </details>
 

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -9,6 +9,8 @@ module Blueprinter
 
     def extract(association_name, object, local_options, options={})
       options_without_default = options.reject { |k,_| k == :default || k == :default_if }
+      # Merge in assocation options hash
+      local_options = local_options.merge(options[:options]) if options[:options].is_a?(Hash)
       value = @extractor.extract(association_name, object, local_options, options_without_default)
       return default_value(options) if use_default_value?(value, options[:default_if])
       view = options[:view] || :default

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -10,6 +10,9 @@ class Blueprinter::Field
   end
 
   def extract(object, local_options)
+    # If this is an association field, merge the association field options in
+    # to the render options
+    local_options = local_options.merge(options[:options]) if association? && options[:options]
     extractor.extract(method, object, local_options, options)
   end
 
@@ -19,6 +22,10 @@ class Blueprinter::Field
   end
 
   private
+
+  def association?
+    !!options[:association]
+  end
 
   def if_callable
     return @if_callable if defined?(@if_callable)

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -10,9 +10,6 @@ class Blueprinter::Field
   end
 
   def extract(object, local_options)
-    # If this is an association field, merge the association field options in
-    # to the render options
-    local_options = local_options.merge(options[:options]) if association? && options[:options]
     extractor.extract(method, object, local_options, options)
   end
 
@@ -22,10 +19,6 @@ class Blueprinter::Field
   end
 
   private
-
-  def association?
-    !!options[:association]
-  end
 
   def if_callable
     return @if_callable if defined?(@if_callable)

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.23.5'.freeze
+  VERSION = '0.24.0'.freeze
 end

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.23.4'.freeze
+  VERSION = '0.23.5'.freeze
 end

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -210,7 +210,7 @@ describe '::Base' do
               association :vehicles, blueprint: vehicle_blueprint, options: { modifier: 'Enhanced' }
             end
           end
-          it('returns json derived from a custom extractor') { should eq(result) }
+          it('returns json using the association options') { should eq(result) }
         end
 
         context 'Given an association :extractor option' do

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -196,6 +196,23 @@ describe '::Base' do
           it { expect{subject}.to raise_error(Blueprinter::BlueprinterError) }
         end
 
+        context 'Given an association :options option' do
+          let(:result) { '{"id":' + obj_id + ',"vehicles":[{"make":"Super Car Enhanced"}]}' }
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              field :make do |vehicle, options|
+                "#{vehicle.make} #{options[:modifier]}"
+              end
+            end
+
+            Class.new(Blueprinter::Base) do
+              field :id
+              association :vehicles, blueprint: vehicle_blueprint, options: { modifier: 'Enhanced' }
+            end
+          end
+          it('returns json derived from a custom extractor') { should eq(result) }
+        end
+
         context 'Given an association :extractor option' do
           let(:result) { '{"id":' + obj_id + ',"vehicles":[{"make":"SUPER CAR"}]}' }
           let(:blueprint) do


### PR DESCRIPTION
Enable passing options from one Blueprint to another via an association.

For example:
```ruby
class VehicleBlueprint < Blueprinter::Base
  identifier :uuid
  field :full_name do |vehicle, options|
    "#{vehicle.model} #{options[:trim]}"
  end
end
class DriverBlueprint < Blueprinter::Base
  identifier :uuid
  view :normal do
    fields :first_name, :last_name
    association :vehicles, blueprint: vehicle_blueprint, options: { trim: 'LX' }
  end
end
```