### PR TITLE
Association extractor with includes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,32 @@ class DriverBlueprint < Blueprinter::Base
 end
 ```
 
+Support eager loading to fix N+1 queries for the association.
+For example:
+```ruby
+class TaskBlueprint < Blueprinter::Base
+  field :name
+  field :description
+end
+
+class ProjectBlueprint < Blueprinter::Base
+  field :name
+end
+
+class MemberBlueprint < Blueprinter::Base
+  field :email
+  association :tasks, blueprint: TaskBlueprint
+  association :projects, blueprint: ProjectBlueprint
+end
+
+class TeamBlueprint < Blueprinter::Base
+  identifier :uuid
+
+  fields :name
+  association :members, blueprint: MemberBlueprint, includes: [:tasks, :projects]
+end
+```
+
 ---
 </details>
 

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -12,6 +12,7 @@ module Blueprinter
       # Merge in assocation options hash
       local_options = local_options.merge(options[:options]) if options[:options].is_a?(Hash)
       value = @extractor.extract(association_name, object, local_options, options_without_default)
+      value = value.includes(options[:includes]) if options.key?(:includes)
       return default_value(options) if use_default_value?(value, options[:default_if])
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)


### PR DESCRIPTION
#160 
### Problem
> I dunno if this issue is valid but here's the definitions I have:
> 
> ```ruby
> # order_group.rb
> class OrderGroup < ApplicationRecord
>   has_many :orders
> end
> 
> # order.rb
> class Order < ApplicationRecord
>   belongs_to :order_group
>   has_many :order_lines
>   has_many :fees
> end
> 
> # blueprints
> 
> # order_group_blueprint.rb
> view :extended do
>   association :orders, blueprint: OrderBlueprint, view: :extended
> end
> 
> # order_blueprint.rb
> view :extended do
>   association :order_lines, blueprint: OrderLineBlueprint
>   association :fees, blueprint: FeeBlueprint
> end
> 
> # some_controller.rb
> ...
> OrderGroupBlueprint.render_as_hash(OrderManifest.all, view: :extended)
> ...
> ```
> 
> Now, how do I eager load the `fees` & `order_lines` when using the blueprint `OrderGroupBlueprint`?
> 
> Feel free to close the issue if this is invalid :) Thank you very much

### Old solution
```ruby
# order_group_blueprint.rb
view :extended do
  association :orders, blueprint: OrderBlueprint, view: :extended do |order_group|
    order_group.orders.includes(:fees, :order_lines)
  end
end
```

### New solution
```ruby
# order_group_blueprint.rb
view :extended do
  association :orders, blueprint: OrderBlueprint, view: :extended, includes: [:fees, :order_lines]
end
```