### PR TITLE
[add] Added an option to exclude fields from associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,44 @@ Output:
 }
 ```
 
+You are also able to exclude unwanted fields from your association with parameter
+`exclude` with single or `excludes` with multiple fields
+
+```ruby
+class ProjectBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :name
+end
+
+class UserBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :email, name: :login
+
+  view :normal do
+    fields :first_name, :last_name
+    association :projects, blueprint: ProjectBlueprint, exclude: :name
+  end
+end
+```
+
+Output:
+```json
+{
+  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
+  "first_name": "John",
+  "last_name": "Doe",
+  "login": "john.doe@some.fake.email.domain",
+  "projects": [
+    {
+      "uuid": "dca94051-4195-42bc-a9aa-eb99f7723c82"
+    },
+    {
+      "uuid": "eb881bb5-9a51-4d27-8a29-b264c30e6160"
+    }
+  ]
+}
+```
+
 It is also possible to pass options from one Blueprint to another via an association.
 For example:
 ```ruby

--- a/lib/blueprinter/extractors/association_extractor.rb
+++ b/lib/blueprinter/extractors/association_extractor.rb
@@ -15,10 +15,16 @@ module Blueprinter
       return default_value(options) if use_default_value?(value, options[:default_if])
       view = options[:view] || :default
       blueprint = association_blueprint(options[:blueprint], value)
+      exclude_fields(blueprint, options)
       blueprint.prepare(value, view_name: view, local_options: local_options)
     end
 
     private
+
+    def exclude_fields(blueprint, options)
+      blueprint.exclude(options[:exclude])
+      blueprint.excludes(*options[:excludes])
+    end
 
     def default_value(association_options)
       association_options.key?(:default) ? association_options.fetch(:default) : Blueprinter.configuration.association_default

--- a/spec/integrations/base_spec.rb
+++ b/spec/integrations/base_spec.rb
@@ -251,6 +251,36 @@ describe '::Base' do
           end
           it('returns json derived from a custom extractor') { should eq(result) }
         end
+
+        context 'Given an association :excludes option' do
+          let(:result) { '{"id":' + obj_id + ',"vehicles":[{"sample_field_2":"sample_field_2"}]}' }
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) do
+              fields :make
+              field(:sample_field) { 'sample_field' }
+              field(:sample_field_2) { 'sample_field_2' }
+            end
+
+            Class.new(Blueprinter::Base) do
+              field :id
+              association(:vehicles, blueprint: vehicle_blueprint, excludes: %i[make sample_field])
+            end
+          end
+          it('returns json with excluded result') { should eq(result) }
+        end
+
+        context 'Give an association :excludes option' do
+          let(:result) { '{"id":' + obj_id + ',"vehicles":[{}]}' }
+          let(:blueprint) do
+            vehicle_blueprint = Class.new(Blueprinter::Base) { fields :make }
+
+            Class.new(Blueprinter::Base) do
+              field :id
+              association(:vehicles, blueprint: vehicle_blueprint, exclude: :make)
+            end
+          end
+          it('returns json with excluded result') { should eq(result) }
+        end
       end
 
       context "Given association is nil" do


### PR DESCRIPTION
Removing unwanted fields from association with `exclude` or `excludes` parameter.

Example;

```ruby
class ProjectBlueprint < Blueprinter::Base
  identifier :uuid
  field :name
end

class UserBlueprint < Blueprinter::Base
  identifier :uuid
  field :email, name: :login

  view :normal do
    fields :first_name, :last_name
    association :projects, blueprint: ProjectBlueprint, exclude: :name
  end
end
```

Output:
```json
{
  "uuid": "733f0758-8f21-4719-875f-262c3ec743af",
  "first_name": "John",
  "last_name": "Doe",
  "login": "john.doe@some.fake.email.domain",
  "projects": [
    {
      "uuid": "dca94051-4195-42bc-a9aa-eb99f7723c82"
    },
    {
      "uuid": "eb881bb5-9a51-4d27-8a29-b264c30e6160"
    }
  ]
}
```