### PR TITLE
Add class for managing deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 0.25.2  - 2020/11/19
+* 🚀 [FEATURE] Make deprecation behavior configurable (`:silence`, `:stderror`, `:raise`). See [#233](https://github.com/procore/blueprinter/pull/248) thanks to [@mcclayton](https://github.com/mcclayton)
+
 ## 0.25.1  - 2020/8/18
-* 🚀 [BUGFIX] Raise Blueprinter::BlueprinterError if Blueprint given is not of class Blueprinter::Base. Before it just raised a generic `undefined method 'prepare'`. See [#233](https://github.com/procore/blueprinter/pull/233) thanks to [@caws](https://github.com/caws)
+* 🐛 [BUGFIX] Raise Blueprinter::BlueprinterError if Blueprint given is not of class Blueprinter::Base. Before it just raised a generic `undefined method 'prepare'`. See [#233](https://github.com/procore/blueprinter/pull/233) thanks to [@caws](https://github.com/caws)
 
 ## 0.25.0  - 2020/7/06
 * 🚀 [FEATURE] Enable default `Blueprinter::Transformer`s to be set in the global configuration. [#222](https://github.com/procore/blueprinter/pull/222). Thanks to [@supremebeing7](https://github.com/supremebeing7).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.25.2  - 2020/11/19
-* 🚀 [FEATURE] Make deprecation behavior configurable (`:silence`, `:stderror`, `:raise`). See [#233](https://github.com/procore/blueprinter/pull/248) thanks to [@mcclayton](https://github.com/mcclayton)
+* 🚀 [FEATURE] Make deprecation behavior configurable (`:silence`, `:stderror`, `:raise`). See [#248](https://github.com/procore/blueprinter/pull/248) thanks to [@mcclayton](https://github.com/mcclayton)
 
 ## 0.25.1  - 2020/8/18
 * 🐛 [BUGFIX] Raise Blueprinter::BlueprinterError if Blueprint given is not of class Blueprinter::Base. Before it just raised a generic `undefined method 'prepare'`. See [#233](https://github.com/procore/blueprinter/pull/233) thanks to [@caws](https://github.com/caws)

--- a/README.md
+++ b/README.md
@@ -870,6 +870,33 @@ Output:
 
 
 <details>
+<summary>Deprecations</summary>
+
+---
+
+When functionality in Blueprinter becomes deprecated, the default behavior is to
+write a deprecation notice to stderror when that deprecated behavior is invoked.
+
+Deprecations can be configured to report at three different levels:
+
+|        Key        |                              Result                             |
+|:-----------------:|:---------------------------------------------------------------:|
+| :stderr (Default) | Deprecations will be written to stderror                        |
+| :raise            | Deprecations will be raised as `Blueprinter::BlueprinterError`s |
+| :silence          | Deprecations will be silenced and will not be raised or logged  |
+
+### Example:
+```ruby
+Blueprinter.configure do |config|
+  config.deprecation = :raise
+end
+```
+
+---
+</details>
+
+
+<details>
 <summary>render_as_hash</summary>
 
 ---

--- a/README.md
+++ b/README.md
@@ -874,16 +874,16 @@ Output:
 
 ---
 
-When functionality in Blueprinter becomes deprecated, the default behavior is to
-write a deprecation notice to stderror when that deprecated behavior is invoked.
+When functionality in Blueprinter is invoked, that has been deprecated, the default behavior is to
+write a deprecation notice to stderror.
 
-Deprecations can be configured to report at three different levels:
+However, deprecations can be configured to report at three different levels:
 
 |        Key        |                              Result                             |
 |:-----------------:|:---------------------------------------------------------------:|
-| :stderr (Default) | Deprecations will be written to stderror                        |
-| :raise            | Deprecations will be raised as `Blueprinter::BlueprinterError`s |
-| :silence          | Deprecations will be silenced and will not be raised or logged  |
+| `:stderr` (Default) | Deprecations will be written to stderror                        |
+| `:raise`            | Deprecations will be raised as `Blueprinter::BlueprinterError`s |
+| `:silence`          | Deprecations will be silenced and will not be raised or logged  |
 
 ### Example:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ However, deprecations can be configured to report at three different levels:
 ### Example:
 ```ruby
 Blueprinter.configure do |config|
-  config.deprecation = :raise
+  config.deprecations = :raise
 end
 ```
 

--- a/lib/blueprinter/base.rb
+++ b/lib/blueprinter/base.rb
@@ -1,5 +1,6 @@
 require_relative 'blueprinter_error'
 require_relative 'configuration'
+require_relative 'deprecation'
 require_relative 'empty_types'
 require_relative 'extractor'
 require_relative 'extractors/association_extractor'

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,6 +1,6 @@
 module Blueprinter
   class Configuration
-    attr_accessor :association_default, :datetime_format, :deprecation, :field_default, :generator, :if, :method, :sort_fields_by, :unless, :extractor_default, :default_transformers
+    attr_accessor :association_default, :datetime_format, :deprecations, :field_default, :generator, :if, :method, :sort_fields_by, :unless, :extractor_default, :default_transformers
 
     VALID_CALLABLES = %i(if unless).freeze
 

--- a/lib/blueprinter/configuration.rb
+++ b/lib/blueprinter/configuration.rb
@@ -1,10 +1,11 @@
 module Blueprinter
   class Configuration
-    attr_accessor :association_default, :datetime_format, :field_default, :generator, :if, :method, :sort_fields_by, :unless, :extractor_default, :default_transformers
+    attr_accessor :association_default, :datetime_format, :deprecation, :field_default, :generator, :if, :method, :sort_fields_by, :unless, :extractor_default, :default_transformers
 
     VALID_CALLABLES = %i(if unless).freeze
 
     def initialize
+      @deprecations = :stderror
       @association_default = nil
       @datetime_format = nil
       @field_default = nil

--- a/lib/blueprinter/deprecation.rb
+++ b/lib/blueprinter/deprecation.rb
@@ -1,0 +1,35 @@
+# @api private
+module Blueprinter
+  class Deprecation
+    class << self
+      VALID_BEHAVIORS = %i(silence stderror raise).freeze
+      MESSAGE_PREFIX = "[DEPRECATION::WARNING] Blueprinter:".freeze
+
+      def report(message)
+        full_msg = qualififed_message(message)
+
+        case behavior
+        when :silence
+          # Silence deprecation (noop)
+        when :stderror
+          warn qualififed_message(full_msg)
+        when :raise
+          raise BlueprinterError, full_msg
+        end
+      end
+
+      private
+
+      def qualififed_message(message)
+        "#{MESSAGE_PREFIX} #{message}"
+      end
+
+      def behavior
+        configured = Blueprinter.configuration.deprecation
+        return configured unless !VALID_BEHAVIORS.include?(configured)
+
+        :stderror
+      end
+    end
+  end
+end

--- a/lib/blueprinter/deprecation.rb
+++ b/lib/blueprinter/deprecation.rb
@@ -6,13 +6,13 @@ module Blueprinter
       MESSAGE_PREFIX = "[DEPRECATION::WARNING] Blueprinter:".freeze
 
       def report(message)
-        full_msg = qualififed_message(message)
+        full_msg = qualified_message(message)
 
         case behavior
         when :silence
           # Silence deprecation (noop)
         when :stderror
-          warn qualififed_message(full_msg)
+          warn qualified_message(full_msg)
         when :raise
           raise BlueprinterError, full_msg
         end
@@ -20,12 +20,12 @@ module Blueprinter
 
       private
 
-      def qualififed_message(message)
+      def qualified_message(message)
         "#{MESSAGE_PREFIX} #{message}"
       end
 
       def behavior
-        configured = Blueprinter.configuration.deprecation
+        configured = Blueprinter.configuration.deprecations
         return configured unless !VALID_BEHAVIORS.include?(configured)
 
         :stderror

--- a/lib/blueprinter/deprecation.rb
+++ b/lib/blueprinter/deprecation.rb
@@ -12,7 +12,7 @@ module Blueprinter
         when :silence
           # Silence deprecation (noop)
         when :stderror
-          warn qualified_message(full_msg)
+          warn full_msg
         when :raise
           raise BlueprinterError, full_msg
         end

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -21,7 +21,7 @@ module Blueprinter
         value.to_s == ""
       else
         Blueprinter::Deprecation.report(
-          "Invalid empty type '#{empty_type}' received. Blueprinter will raise an error in future versions."\
+          "Invalid empty type '#{empty_type}' received. Blueprinter will raise an error in the next major version."\
           "Must be one of [nil, Blueprinter::EMPTY_COLLECTION, Blueprinter::EMPTY_HASH, Blueprinter::EMPTY_STRING]"
         )
       end

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -10,6 +10,8 @@ module Blueprinter
     private
 
     def use_default_value?(value, empty_type)
+      return value.nil? unless empty_type
+
       case empty_type
       when Blueprinter::EMPTY_COLLECTION
         array_like?(value) && value.empty?
@@ -18,7 +20,10 @@ module Blueprinter
       when Blueprinter::EMPTY_STRING
         value.to_s == ""
       else
-        value.nil?
+        Blueprinter::Deprecation.report(
+          "Invalid empty type '#{empty_type}' received. Blueprinter will raise an error in future versions."\
+          "Must be one of [nil, Blueprinter::EMPTY_COLLECTION, Blueprinter::EMPTY_HASH, Blueprinter::EMPTY_STRING]"
+        )
       end
     end
   end

--- a/lib/blueprinter/field.rb
+++ b/lib/blueprinter/field.rb
@@ -34,7 +34,7 @@ class Blueprinter::Field
     callable = old_callable_from(condition)
 
     if callable && callable.arity == 2
-      warn "[DEPRECATION] Blueprinter :#{condition} conditions now expects 3 arguments instead of 2."
+      Blueprinter::Deprecation.report("`:#{condition}` conditions now expects 3 arguments instead of 2.")
       ->(_field_name, obj, options) { callable.call(obj, options) }
     else
       callable

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.25.1'.freeze
+  VERSION = '0.25.2'.freeze
 end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -181,7 +181,7 @@ shared_examples 'Base::render' do
     it('reports a deprecation message') do
       allow(Blueprinter::Deprecation).to receive(:report)
       blueprint.render(obj)
-      expect(Blueprinter::Deprecation).to have_received(:report).with(match(/Invalid empty type '.*' received. Blueprinter will raise an error in future versions./))
+      expect(Blueprinter::Deprecation).to have_received(:report).with(match(/Invalid empty type '.*' received. Blueprinter will raise an error in the next major version./))
     end
   end
 

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -55,9 +55,9 @@ describe 'Blueprinter' do
       expect(Blueprinter.configuration.field_default).to eq("N/A")
     end
 
-    it 'should set the `deprecation` option' do
-      Blueprinter.configure { |config| config.deprecation = :silence }
-      expect(Blueprinter.configuration.deprecation).to eq(:silence)
+    it 'should set the `deprecations` option' do
+      Blueprinter.configure { |config| config.deprecations = :silence }
+      expect(Blueprinter.configuration.deprecations).to eq(:silence)
     end
 
     it 'should set the `association_default` option' do

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -55,6 +55,11 @@ describe 'Blueprinter' do
       expect(Blueprinter.configuration.field_default).to eq("N/A")
     end
 
+    it 'should set the `deprecation` option' do
+      Blueprinter.configure { |config| config.deprecation = :silence }
+      expect(Blueprinter.configuration.deprecation).to eq(:silence)
+    end
+
     it 'should set the `association_default` option' do
       Blueprinter.configure { |config| config.association_default = {} }
       expect(Blueprinter.configuration.association_default).to eq({})

--- a/spec/units/deprecation_spec.rb
+++ b/spec/units/deprecation_spec.rb
@@ -15,7 +15,7 @@ describe 'Blueprinter::Deprecation' do
         Blueprinter::Deprecation.report(TEST_MESSAGE)
         $stderr.rewind
         stderr_output = $stderr.string.chomp
-        expect(stderr_output).to include("[DEPRECATION::WARNING] Blueprinter: #{TEST_MESSAGE}")
+        expect(stderr_output).to eql("[DEPRECATION::WARNING] Blueprinter: #{TEST_MESSAGE}")
       end
 
       after do

--- a/spec/units/deprecation_spec.rb
+++ b/spec/units/deprecation_spec.rb
@@ -1,0 +1,56 @@
+describe 'Blueprinter::Deprecation' do
+  describe '#report' do
+    TEST_MESSAGE = "Test Message"
+
+    after { reset_blueprinter_config! }
+
+    describe "when deprecation behavior is `:stderror`" do
+      before do
+        Blueprinter.configure { |config| config.deprecation = :stderror }
+        @orig_stderr = $stderr
+        $stderr = StringIO.new
+      end
+
+      it('writes deprecation warning message to $stderr') do
+        Blueprinter::Deprecation.report(TEST_MESSAGE)
+        $stderr.rewind
+        stderr_output = $stderr.string.chomp
+        expect(stderr_output).to include("[DEPRECATION::WARNING] Blueprinter: #{TEST_MESSAGE}")
+      end
+
+      after do
+        $stderr = @orig_stderr
+      end
+    end
+
+    describe "when deprecation behavior is `:silence`" do
+      before do
+        Blueprinter.configure { |config| config.deprecation = :silence }
+        @orig_stderr = $stderr
+        $stderr = StringIO.new
+      end
+
+      it('does not warn or raise deprecation message') do
+        expect {Blueprinter::Deprecation.report(TEST_MESSAGE)}.not_to raise_error
+        $stderr.rewind
+        stderr_output = $stderr.string.chomp
+        expect(stderr_output).not_to include("[DEPRECATION::WARNING] Blueprinter: #{TEST_MESSAGE}")
+      end
+
+      after do
+        $stderr = @orig_stderr
+      end
+    end
+
+    describe "when deprecation behavior is `:raise`" do
+      before do
+        Blueprinter.configure { |config| config.deprecation = :raise }
+      end
+
+      it('raises BlueprinterDeprecationError with deprecation message') do
+        expect {Blueprinter::Deprecation.report(TEST_MESSAGE)}.
+          to raise_error(Blueprinter::BlueprinterError, "[DEPRECATION::WARNING] Blueprinter: #{TEST_MESSAGE}")
+      end
+    end
+  end
+end

--- a/spec/units/deprecation_spec.rb
+++ b/spec/units/deprecation_spec.rb
@@ -6,7 +6,7 @@ describe 'Blueprinter::Deprecation' do
 
     describe "when deprecation behavior is `:stderror`" do
       before do
-        Blueprinter.configure { |config| config.deprecation = :stderror }
+        Blueprinter.configure { |config| config.deprecations = :stderror }
         @orig_stderr = $stderr
         $stderr = StringIO.new
       end
@@ -25,7 +25,7 @@ describe 'Blueprinter::Deprecation' do
 
     describe "when deprecation behavior is `:silence`" do
       before do
-        Blueprinter.configure { |config| config.deprecation = :silence }
+        Blueprinter.configure { |config| config.deprecations = :silence }
         @orig_stderr = $stderr
         $stderr = StringIO.new
       end
@@ -44,7 +44,7 @@ describe 'Blueprinter::Deprecation' do
 
     describe "when deprecation behavior is `:raise`" do
       before do
-        Blueprinter.configure { |config| config.deprecation = :raise }
+        Blueprinter.configure { |config| config.deprecations = :raise }
       end
 
       it('raises BlueprinterDeprecationError with deprecation message') do


### PR DESCRIPTION
Adding in a class for managing deprecations and introducing a deprecation configuration option to the blueprinter config.
Deprecations can be set to the following behavior options:

When functionality in Blueprinter is invoked, that has been deprecated, the default behavior is to
write a deprecation notice to stderror.

However, deprecations can be configured to report at three different levels:

|        Key        |                              Result                             |
|:-----------------:|:---------------------------------------------------------------:|
| `:stderr` (Default) | Deprecations will be written to stderror                        |
| `:raise`            | Deprecations will be raised as `Blueprinter::BlueprinterError`s |
| `:silence`          | Deprecations will be silenced and will not be raised or logged  |

### Example:
```ruby
Blueprinter.configure do |config|
  config.deprecation = :raise
end
```