### PR TITLE
Add empty JSON as a valid empty type

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,9 @@ An empty array or empty active record collection.
 #### Blueprinter::EMPTY_HASH
 An empty hash.
 
+#### Blueprinter::EMPTY_JSONB
+An empty json blob.
+
 #### Blueprinter::EMPTY_STRING
 An empty string or symbol.
 

--- a/lib/blueprinter/empty_types.rb
+++ b/lib/blueprinter/empty_types.rb
@@ -3,6 +3,7 @@ require_relative 'helpers/type_helpers'
 module Blueprinter
   EMPTY_COLLECTION = "empty_collection".freeze
   EMPTY_HASH = "empty_hash".freeze
+  EMPTY_JSONB = "empty_jsonb".freeze
   EMPTY_STRING = "empty_string".freeze
 
   module EmptyTypes
@@ -17,6 +18,8 @@ module Blueprinter
         value.is_a?(Hash) && value.empty?
       when Blueprinter::EMPTY_STRING
         value.to_s == ""
+      when Blueprinter::EMPTY_JSONB
+        JSON.parse(value).empty?
       else
         value.nil?
       end

--- a/spec/integrations/shared/base_render_examples.rb
+++ b/spec/integrations/shared/base_render_examples.rb
@@ -171,6 +171,20 @@ shared_examples 'Base::render' do
     it('uses the correct default values') { should eq(result) }
   end
 
+  context 'Given default_if option is Blueprinter::EMTPY_JSONB' do
+    before do
+      obj[:first_name] = "{}"
+    end
+
+    let(:blueprint) do
+      Class.new(Blueprinter::Base) do
+        field :first_name, default_if: Blueprinter::EMPTY_JSONB, default: []
+      end
+    end
+    let(:result) { '{"first_name":[]}' }
+    it('raises a BlueprinterError') { should eq(result) }
+  end
+
   context "Given blueprint has ::field with nil value" do
     before do
       obj[:first_name] = nil


### PR DESCRIPTION
Adds a new empty type called `Blueprinter::EMPTY_JSONB` to represent possible empty values from jsonb columns in databases.