### PR TITLE
v0.19.1 | Performance optimisations on v0.19.0

### DIFF
--- a/lib/blueprinter/extractors/auto_extractor.rb
+++ b/lib/blueprinter/extractors/auto_extractor.rb
@@ -5,18 +5,24 @@ module Blueprinter
       @public_send_extractor = PublicSendExtractor.new
       @block_extractor = BlockExtractor.new
       @datetime_formatter = DateTimeFormatter.new
+      @config_datetime_format = Blueprinter.configuration.datetime_format
+      @config_field_default = Blueprinter.configuration.field_default
     end
 
     def extract(field_name, object, local_options, options = {})
-      extraction = extractor(object, options).extract(field_name, object, local_options, options)
-      value = @datetime_formatter.format(extraction, options)
+      value = extractor(object, options).extract(field_name, object, local_options, options)
+      value = @datetime_formatter.format(value, options) if format_datetime?(options)
       value.nil? ? default_value(options) : value
     end
 
     private
 
+    def format_datetime?(options)
+      options.key?(:datetime_format) || @config_datetime_format
+    end
+
     def default_value(field_options)
-      field_options.key?(:default) ? field_options.fetch(:default) : Blueprinter.configuration.field_default
+      field_options.key?(:default) ? field_options.fetch(:default) : @config_field_default
     end
 
     def extractor(object, options)

--- a/lib/blueprinter/helpers/base_helpers.rb
+++ b/lib/blueprinter/helpers/base_helpers.rb
@@ -20,15 +20,19 @@ module Blueprinter
       end
 
       def prepare_data(object, view_name, local_options)
+        view_fields = view_collection.fields_for(view_name)
+        view_transformers = view_collection.transformers(view_name)
         if array_like?(object)
           object.map do |obj|
             object_to_hash(obj,
-                          view_name: view_name,
+                          view_fields: view_fields,
+                          view_transformers: view_transformers,
                           local_options: local_options)
           end
         else
           object_to_hash(object,
-                        view_name: view_name,
+                        view_fields: view_fields,
+                        view_transformers: view_transformers,
                         local_options: local_options)
         end
       end
@@ -43,12 +47,12 @@ module Blueprinter
         subclass.send(:view_collection).inherit(view_collection)
       end
 
-      def object_to_hash(object, view_name:, local_options:)
-        result_hash = view_collection.fields_for(view_name).each_with_object({}) do |field, hash|
+      def object_to_hash(object, view_fields:, view_transformers:, local_options:)
+        result_hash = view_fields.each_with_object({}) do |field, hash|
           next if field.skip?(field.name, object, local_options)
            hash[field.name] = field.extract(object, local_options)
         end
-        view_collection.transformers(view_name).each do |transformer|
+        view_transformers.each do |transformer|
            transformer.transform(result_hash,object,local_options)
         end
         result_hash

--- a/lib/blueprinter/version.rb
+++ b/lib/blueprinter/version.rb
@@ -1,3 +1,3 @@
 module Blueprinter
-  VERSION = '0.19.0'
+  VERSION = '0.19.1'
 end


### PR DESCRIPTION
### Benchmark comparison:

Output on Ruby 2.6.9, MacBook Pro (15-inch, 2018, 2.2 GHz 6-Core Intel Core i7)

[benchmark code](https://gist.github.com/midhun-thimmapuram/f6b45744e77f01750db64eb5f7a7a61e)

_blueprinter 0.19.0 (procore)_

```
Rehearsal -----------------------------------------------
blueprinter   0.276568   0.005310   0.281878 (  0.283335)
-------------------------------------- total: 0.281878sec

                  user     system      total        real
blueprinter   0.255435   0.005273   0.260708 (  0.264110)
Warming up --------------------------------------
         blueprinter     1.000  i/100ms
Calculating -------------------------------------
         blueprinter      3.644  (± 3.4%) i/s -     37.000  in  10.300638s
                   with 95.0% confidence
Calculating -------------------------------------
         blueprinter    35.117M memsize (     0.000  retained)
                       279.762k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```
_With current PR optimisations (0.19.1)_
```
Rehearsal -----------------------------------------------
blueprinter   0.177554   0.002541   0.180095 (  0.180207)
-------------------------------------- total: 0.180095sec

                  user     system      total        real
blueprinter   0.162315   0.000225   0.162540 (  0.162751)
Warming up --------------------------------------
         blueprinter     1.000  i/100ms
Calculating -------------------------------------
         blueprinter      5.852  (± 1.8%) i/s -     59.000  in  10.128980s
                   with 95.0% confidence
Calculating -------------------------------------
         blueprinter    23.839M memsize (     0.000  retained)
                       159.889k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```