### PR TITLE
Memoize #fields_for(view)

### DIFF
--- a/lib/blueprinter/view_collection.rb
+++ b/lib/blueprinter/view_collection.rb
@@ -8,6 +8,7 @@ module Blueprinter
         default: View.new(:default)
       }
       @sort_by_definition = Blueprinter.configuration.sort_fields_by.eql?(:definition)
+      @fields_for = {}
     end
 
     def inherit(view_collection)
@@ -21,12 +22,15 @@ module Blueprinter
     end
 
     def fields_for(view_name)
-      return identifier_fields if view_name == :identifier
+      @fields_for[view_name] ||=
+        if view_name == :identifier
+          identifier_fields
+        else
+          fields, excluded_fields = sortable_fields(view_name)
+          sorted_fields = sort_by_definition ? sort_by_def(view_name, fields) : fields.values.sort_by(&:name)
 
-      fields, excluded_fields = sortable_fields(view_name)
-      sorted_fields = sort_by_definition ? sort_by_def(view_name, fields) : fields.values.sort_by(&:name)
-
-      (identifier_fields + sorted_fields).reject { |field| excluded_fields.include?(field.name) }
+          (identifier_fields + sorted_fields).reject { |field| excluded_fields.include?(field.name) }
+        end
     end
 
     def transformers(view_name)


### PR DESCRIPTION
This PR is based on https://github.com/procore/blueprinter/pull/289 and optimizes code in a more general way.

Benchmarks (Ruby 3.0.1, macOS 12.4, M1, 16GB)

```
$ ruby blueprinter_benchmark.rb

blueprinter:
{:id=>0, :number=>0, :title=>"Issue 0", :labels=>[{:id=>1, :name=>"Label 1", :color=>"ffffff"}, {:id=>0, :name=>"Label 0", :color=>"ffffff"}, {:id=>3, :name=>"Label 3", :color=>"ffffff"}, {:id=>2, :name=>"Label 2", :color=>"ffffff"}], :user=>{:id=>9, :login=>"User 9"}}

Rehearsal -----------------------------------------------
blueprinter   0.280623   0.002392   0.283015 (  0.283088)
-------------------------------------- total: 0.283015sec

                  user     system      total        real
blueprinter   0.264045   0.001605   0.265650 (  0.265878)
Warming up --------------------------------------
         blueprinter     1.000  i/100ms
Calculating -------------------------------------
         blueprinter      3.478  (± 0.9%) i/s -     35.000  in  10.072562s
                   with 95.0% confidence
Calculating -------------------------------------
         blueprinter    43.458M memsize (     0.000  retained)
                       479.885k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```

```
$ OPTIMIZED=1 ruby blueprinter_benchmark.rb

blueprinter:
{:id=>0, :number=>0, :title=>"Issue 0", :labels=>[{:id=>0, :name=>"Label 0", :color=>"ffffff"}, {:id=>1, :name=>"Label 1", :color=>"ffffff"}], :user=>{:id=>0, :login=>"User 0"}}

Rehearsal -----------------------------------------------
blueprinter   0.211679   0.007692   0.219371 (  0.219716)
-------------------------------------- total: 0.219371sec

                  user     system      total        real
blueprinter   0.167957   0.002523   0.170480 (  0.174781)
Warming up --------------------------------------
         blueprinter     1.000  i/100ms
Calculating -------------------------------------
         blueprinter      5.410  (± 4.6%) i/s -     52.000  in  10.166932s
                   with 95.0% confidence
Calculating -------------------------------------
         blueprinter    18.133M memsize (     0.000  retained)
                       160.145k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```

```
$ OPTIMIZED=2 ruby blueprinter_benchmark.rb

blueprinter:
{:id=>0, :number=>0, :title=>"Issue 0", :labels=>[{:id=>3, :name=>"Label 3", :color=>"ffffff"}, {:id=>1, :name=>"Label 1", :color=>"ffffff"}], :user=>{:id=>5, :login=>"User 5"}}

Rehearsal -----------------------------------------------
blueprinter   0.176880   0.004073   0.180953 (  0.180964)
-------------------------------------- total: 0.180953sec

                  user     system      total        real
blueprinter   0.172180   0.002403   0.174583 (  0.176474)
Warming up --------------------------------------
         blueprinter     1.000  i/100ms
Calculating -------------------------------------
         blueprinter      5.426  (± 1.9%) i/s -     54.000  in  10.059275s
                   with 95.0% confidence
Calculating -------------------------------------
         blueprinter    12.335M memsize (     0.000  retained)
                        79.930k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```

Thanks @midhun-thimmapuram for your investigation 🙏 