### PR TITLE
Devprod 98/ecosystem division

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,4 +24,4 @@ spec:
   system: App Management | Developer Metrics | Marketplace | Sidepanel | Support Documentation
   type: library
   lifecycle: ga
-  owner: team-dmx
+  owner: team-ecosystem-core

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   name: blueprinter
   annotations:
     github.com/project-slug: procore/blueprinter
-    github.com/team-slug: procore/team-ecosystem-core
+    github.com/team-slug: procore/team-developer-marketplace-experience
     circleci.com/project-slug: github/procore/blueprinter
     bugsnag.com/project-name: Blueprinter
   title: Blueprinter

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,4 +24,4 @@ spec:
   system: App Management | Developer Metrics | Marketplace | Sidepanel | Support Documentation
   type: library
   lifecycle: ga
-  owner: team-ecosystem-core
+  owner: team-developer-marketplace-experience


### PR DESCRIPTION
Team name change from `team-ecosystem-core` to `team-developer-marketplace-experience`.