### PR TITLE
Check if an array_like object is an Enumerable

### DIFF
--- a/lib/blueprinter/helpers/type_helpers.rb
+++ b/lib/blueprinter/helpers/type_helpers.rb
@@ -7,7 +7,7 @@ module Blueprinter
     end
 
     def array_like?(object)
-      object.is_a?(Array) || active_record_relation?(object)
+      object.is_a?(Enumerable) || active_record_relation?(object)
     end
   end
 end


### PR DESCRIPTION
## Context
When passing an array like `ActiveModel::Errors`, I'm unable to render blueprint because it does not pass `array_like?` condition. Both `[]` and `ActiveModel::Errors` are `Enumerable`, I'm proposing to check if array is `Enumerable` instead. 

Let me know what you guys think? Thank you.


## Usage Example
### Before
```ruby
ModelBlueprint.render(model.errors.full_messages, root: :errors)
```

### After
```ruby
ModelBlueprint.render(model.errors, root: :errors)
```